### PR TITLE
load_datagetter_data: Skip malformed JSON

### DIFF
--- a/datastore/db/management/commands/load_datagetter_data.py
+++ b/datastore/db/management/commands/load_datagetter_data.py
@@ -95,10 +95,9 @@ class Command(BaseCommand):
 
                 db.Grant.objects.bulk_create(grant_bulk_insert)
                 grants_added = grants_added + len(grant_data["grants"])
-            except (FileNotFoundError, KeyError, TypeError) as e:
+            except (FileNotFoundError, KeyError, TypeError, json.JSONDecodeError) as e:
                 print(
-                    "Skipping '%s' as it does not exist in supplied dataset" % e,
-                    file=self.stdout,
+                    "Skipping loading due to: '%s'" % e, file=self.stdout,
                 )
                 pass
 


### PR DESCRIPTION
If a download has saved malformed JSON except this error to allow the
rest of the dataset to continue to load. This could happen if the
datagetter downloads for example a 404 page as a json file.