### PR TITLE
additional_data: local_files: Fix incorrect list

### DIFF
--- a/datastore/additional_data/sources/local_files.py
+++ b/datastore/additional_data/sources/local_files.py
@@ -14,7 +14,9 @@ class LocalFilesSource(object):
     # These are currently used in GrantNav.
     ADDITIONAL_FIELDS = [
         "recipientWardNameGeoCode",
-        "recipientWardName" "recipientDistrictName" "recipientDistrictGeoCode",
+        "recipientWardName",
+        "recipientDistrictName",
+        "recipientDistrictGeoCode",
         "recipientRegionName",
         "recipientLocation",
         "id_and_name",


### PR DESCRIPTION
Missing commas to separate additional fields.

Fixes issue https://github.com/ThreeSixtyGiving/datastore/issues/42