### PR TITLE
db: models: Set default ordering by publisher prefix

### DIFF
--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -153,6 +153,9 @@ class SourceFile(models.Model):
     def __str__(self):
         return self.data["datagetter_metadata"]["datetime_downloaded"]
 
+    class Meta:
+        ordering = ["data__publisher__prefix"]
+
 
 class Publisher(models.Model):
 
@@ -178,6 +181,7 @@ class Publisher(models.Model):
 
     class Meta:
         unique_together = ("getter_run", "prefix")
+        ordering = ["prefix"]
 
 
 class Grant(models.Model):


### PR DESCRIPTION
Sets a sensible human default for the ordering