### PR TITLE
additional_data: load_all_org_data manually set source ids

### DIFF
--- a/datastore/additional_data/sources/load_all_org_data.sh
+++ b/datastore/additional_data/sources/load_all_org_data.sh
@@ -16,7 +16,7 @@
 ./manage.py load_org_data https://findthatcharity.uk/orgid/source/pla.csv
 ./manage.py load_org_data https://findthatcharity.uk/orgid/source/nhsods.csv
 ./manage.py load_org_data https://findthatcharity.uk/orgid/source/rsl.csv
-./manage.py load_org_data https://findthatcharity.uk/orgid/source/gias.csv
-./manage.py load_org_data https://findthatcharity.uk/orgid/source/nideptofeducation.csv
-./manage.py load_org_data https://findthatcharity.uk/orgid/source/schoolsscotland.csv
-./manage.py load_org_data https://findthatcharity.uk/orgid/source/walesschools.csv
+./manage.py load_org_data https://findthatcharity.uk/orgid/source/gias.csv schools_gias
+./manage.py load_org_data https://findthatcharity.uk/orgid/source/nideptofeducation.csv schools_ni
+./manage.py load_org_data https://findthatcharity.uk/orgid/source/schoolsscotland.csv schools_scotland
+./manage.py load_org_data https://findthatcharity.uk/orgid/source/walesschools.csv schools_wales


### PR DESCRIPTION
Manually set the source ids as these are usually guessed from the file
name we can specify them as part of the command. The file names may be
updated in the future to match these source ids.

Related: https://github.com/ThreeSixtyGiving/datastore/issues/73