### PR TITLE
additional_data: Add new module to provide recipient types

### DIFF
--- a/datastore/additional_data/generator.py
+++ b/datastore/additional_data/generator.py
@@ -7,6 +7,7 @@ from additional_data.sources.additional_data_recipient_location import (
     AdditionalDataRecipientLocation,
 )
 from additional_data.sources.codelist_code import CodeListSource
+from additional_data.sources.tsg_recipient_types import TSGRecipientTypesSource
 
 
 class AdditionalDataGenerator(object):
@@ -20,6 +21,7 @@ class AdditionalDataGenerator(object):
         self.tsg_org_types = TSGOrgTypesSource()
         self.additional_data_recipient_location = AdditionalDataRecipientLocation()
         self.code_lists = CodeListSource()
+        self.tsg_recipient_type = TSGRecipientTypesSource()
         # Initialise Other Sources here
 
     def create(self, grant):
@@ -38,5 +40,6 @@ class AdditionalDataGenerator(object):
             grant, additional_data
         )
         self.code_lists.update_additional_data(grant, additional_data)
+        self.tsg_recipient_type.update_additional_data(grant, additional_data)
 
         return additional_data

--- a/datastore/additional_data/sources/tsg_recipient_types.py
+++ b/datastore/additional_data/sources/tsg_recipient_types.py
@@ -1,0 +1,13 @@
+class TSGRecipientTypesSource(object):
+    """This adds a custom ThreeSixtyGiving recipient type of recipient to the additional data
+    For now this is just organisation/individual
+    """
+
+    ADDITIONAL_DATA_KEY = "TSGRecipientType"
+
+    def update_additional_data(self, grant, additional_data):
+        try:
+            grant["recipientOrganization"][0]["id"]
+            additional_data[self.ADDITIONAL_DATA_KEY] = "Organisation"
+        except (KeyError):
+            additional_data[self.ADDITIONAL_DATA_KEY] = "Individual"

--- a/datastore/tests/test_additional_data_tsgrecipienttype.py
+++ b/datastore/tests/test_additional_data_tsgrecipienttype.py
@@ -1,0 +1,48 @@
+from django.test import TestCase
+from additional_data.sources.tsg_recipient_types import TSGRecipientTypesSource
+
+
+class TestTSGRecipientTypes(TestCase):
+    def test_recipient_is_individual(self):
+        source = TSGRecipientTypesSource()
+
+        grant = {
+            "recipientIndividual": {
+                "id": "1345-individual",
+                "name": "Individual Recipient",
+            },
+        }
+
+        additional_data_in = {}
+
+        additional_data_out = {"TSGRecipientType": "Individual"}
+
+        source.update_additional_data(grant, additional_data_in)
+
+        self.assertEqual(
+            additional_data_in,
+            additional_data_out,
+            "The expected additional data isn't correct",
+        )
+
+    def test_recipient_is_organisation(self):
+
+        source = TSGRecipientTypesSource()
+
+        grant = {
+            "recipientOrganization": [
+                {"id": "GB-COH-123553", "name": "Organisation that needs a grant"}
+            ],
+        }
+
+        additional_data_in = {}
+
+        additional_data_out = {"TSGRecipientType": "Organisation"}
+
+        source.update_additional_data(grant, additional_data_in)
+
+        self.assertEqual(
+            additional_data_in,
+            additional_data_out,
+            "The expected additional data isn't correct",
+        )


### PR DESCRIPTION
This adds a field in the additional data to provide the recipient type. Room has been left for the future to expand this to do a similar job to that of the TSG Funding Organisation Type. This is a helper field mostly for convenience of filtering in tools such as GrantNav.