### PR TITLE
additional_data: s/toIndividualDetails/toIndividualsDetails

### DIFF
--- a/datastore/additional_data/sources/codelist_code.py
+++ b/datastore/additional_data/sources/codelist_code.py
@@ -84,7 +84,7 @@ class CodeListSource(object):
             pass
 
         additional_data["codeListLookup"] = {
-            "toIndividualDetails": {
+            "toIndividualsDetails": {
                 "primaryGrantReason": primaryGrantReason,
                 "secondaryGrantReason": secondaryGrantReason,
                 "grantPurpose": grantPurpose,

--- a/datastore/tests/test_additional_data_codelist_code.py
+++ b/datastore/tests/test_additional_data_codelist_code.py
@@ -19,7 +19,7 @@ class TestCodeLists(TestCase):
 
         additional_data_out = {
             "codeListLookup": {
-                "toIndividualDetails": {
+                "toIndividualsDetails": {
                     "primaryGrantReason": "Mental Health",
                     "secondaryGrantReason": "",
                     "grantPurpose": ["Exceptional costs"],


### PR DESCRIPTION
Make sure the additional data field names match the standard.

continuation of 60c9dfed142484d936590180135d5781a3b1fa49 . This has caught me out 3 times now! the field name reads as a plural but the field is singular!