### PR TITLE
prometheus: Only update gauges if we're in an idle and ready state

### DIFF
--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -379,3 +379,16 @@ class Status(models.Model):
     what = models.CharField(max_length=200)
     status = models.CharField(max_length=200, default=Statuses.IDLE)
     when = models.DateTimeField(auto_now=True)
+
+    @staticmethod
+    def all_idle_and_ready():
+        try:
+            return (
+                Status.objects.get(what=Statuses.DATAGETTER).status == Statuses.IDLE
+                and Status.objects.get(what=Statuses.GRANTNAV_DATA_PACKAGE).status
+                == Statuses.READY
+                and Status.objects.get(what=Statuses.DATASTORE).status == Statuses.IDLE
+            )
+        except Status.DoesNotExist:
+            # We have no status set so we consider this as idle and ready
+            return True

--- a/datastore/prometheus/views.py
+++ b/datastore/prometheus/views.py
@@ -56,9 +56,11 @@ class ServiceMetrics(View):
         NUM_ERRORS_LOGGED.set(errors)
 
     def _total_latest_grants(self):
+
         total_current = db.Latest.objects.get(
             series=db.Latest.CURRENT
         ).grant_set.count()
+
         TOTAL_CURRENT_LATEST_GRANTS.set(total_current)
 
         total_prev = db.Latest.objects.get(series=db.Latest.PREVIOUS).grant_set.count()
@@ -84,10 +86,12 @@ class ServiceMetrics(View):
             NUM_OK_SOURCES_IN_LAST_RUN.set(0)
 
     def get(self, *args, **kwargs):
-        # Update gauges
-        self._num_errors_log()
-        self._total_latest_grants()
-        self._total_datagetter_grants()
-        self._total_num_sources_in_last_run()
+        # Update gauges unless we're in the middle of processing/loading
+        if db.Status.all_idle_and_ready():
+            self._num_errors_log()
+            self._total_latest_grants()
+            self._total_datagetter_grants()
+            self._total_num_sources_in_last_run()
+
         # Generate latest uses default of the global registry
         return HttpResponse(generate_latest(), content_type="text/plain")


### PR DESCRIPTION
This helps us avoid a false positive alert if things are in progress and alerts are comparing the number of grants with those in the live tools.