### PR TITLE
data_quality: quality_data: Fix typo in quality metric name

### DIFF
--- a/datastore/data_quality/quality_data.py
+++ b/datastore/data_quality/quality_data.py
@@ -194,7 +194,7 @@ class SourceFilesStats(object):
         if self.get_total_recipient_individuals() > 0:
             self.quality_query_parameters.update(
                 {
-                    "hasRecipientIndidualsCodelists": {
+                    "hasRecipientIndividualsCodelists": {
                         "quality__IndividualsCodeListsNotPresent__fail": False
                     },
                 }


### PR DESCRIPTION
s/hasRecipientIndidualsCodelists/hasRecipientIndividualsCodelists/

@mariongalley FYI this should fix the badge not appearing for publishers to individuals codelists 