### PR TITLE
data_quality: quality_data: Rewrite 50% external org id cal

### DIFF
--- a/datastore/data_quality/quality_data.py
+++ b/datastore/data_quality/quality_data.py
@@ -83,12 +83,7 @@ def create(grants):
             # in the org-ids in the recipient organisation for a grant.
             #
             # We can use this test's data to fill in the data for the two new tests RecipientOrgPrefixExternal and RecipientOrgPrefix50pcExternal
-            quality_results["RecipientOrgPrefix50pcExternal"] = {
-                "fail": test[0]["percentage"] >= 0.5,
-                "count": test[0]["count"] / 2,
-                "percentage": 1,
-            }
-
+            # RecipientOrgPrefixExternal is  (number of grants) - (count of recipient orgs with a 360 prefix) - (recipient individual grants)
             grants_recipient_ext_org = (
                 cove_results["grants_aggregates"]["count"]
                 - cove_results["grants_aggregates"]["recipient_individuals_count"]
@@ -103,6 +98,16 @@ def create(grants):
                 ),
                 "fail": grants_recipient_ext_org == 0,
                 "heading": "Recipient Orgs with external org identifier",
+            }
+
+            # Add test to see if more than 50% of the recipient org ids are external
+            quality_results["RecipientOrgPrefix50pcExternal"] = {
+                "fail": quality_results["RecipientOrgPrefixExternal"]["percentage"]
+                < 0.5,
+                "count": grants_recipient_ext_org,
+                "percentage": quality_results["RecipientOrgPrefixExternal"][
+                    "percentage"
+                ],
             }
 
     aggregates = {

--- a/datastore/tests/test_quality_data.py
+++ b/datastore/tests/test_quality_data.py
@@ -103,9 +103,9 @@ class TestDataQualityData(TestCase):
                 "percentage": 0.0,
             },
             "RecipientOrgPrefix50pcExternal": {
-                "count": 2.5,
+                "count": 0,
                 "fail": True,
-                "percentage": 1,
+                "percentage": 0,
             },
         }
 


### PR DESCRIPTION
Use the total number of external org ids as the basis for this test instead of calculating based on the original test for 360 prefixes.