### PR TITLE
db: commands: Add load_data_package

### DIFF
--- a/datastore/db/management/commands/load_data_package.py
+++ b/datastore/db/management/commands/load_data_package.py
@@ -1,0 +1,61 @@
+import copy
+
+import db.models as db
+
+from db.management.commands.load_datagetter_data import (
+    Command as LoadDatagetterDataCommand,
+)
+
+
+class Command(LoadDatagetterDataCommand):
+    help = (
+        "Loads data that has been output by the datastore's create_data_package command"
+    )
+    """ Load a data package created by create_data_package.
+    Note:
+          * This performs no additional_data processing on the incoming data
+          * This separates the data by treating it like a new GetterRun
+    """
+
+    def load_data(self):
+        grants_added = 0
+        dataset = self.load_dataset_data()
+
+        getter_run = db.GetterRun.objects.create()
+
+        for ob in dataset:
+            prefix = ob["publisher"]["prefix"]
+            publisher, c = db.Publisher.objects.get_or_create(
+                getter_run=getter_run,
+                prefix=prefix,
+                data=ob["publisher"],
+                org_id=ob["publisher"].get("org_id", "unknown"),
+                name=ob["publisher"]["name"],
+                source=db.Entity.PUBLISHER,
+            )
+
+            source_file = db.SourceFile.objects.create(data=ob, getter_run=getter_run)
+
+            grant_data = self.load_grant_data(ob["datagetter_metadata"]["json"])
+
+            grant_bulk_insert = []
+
+            for grant in grant_data["grants"]:
+                additional_data = copy.deepcopy(grant["additional_data"])
+                del grant["additional_data"]
+
+                grant_bulk_insert.append(
+                    db.Grant(
+                        grant_id=grant["id"],
+                        source_file=source_file,
+                        publisher=publisher,
+                        data=grant,
+                        additional_data=additional_data,
+                        getter_run=getter_run,
+                    )
+                )
+
+            db.Grant.objects.bulk_create(grant_bulk_insert)
+            grants_added = grants_added + len(grant_data["grants"])
+
+        return grants_added

--- a/datastore/db/management/commands/load_datagetter_data.py
+++ b/datastore/db/management/commands/load_datagetter_data.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             nargs=1,
             action="store",
             dest="data_dir",
-            help="The location of the data dir created by datagetter",
+            help="The location of the data dir",
         )
 
         parser.add_argument(

--- a/datastore/tests/test_commands.py
+++ b/datastore/tests/test_commands.py
@@ -15,11 +15,13 @@ class CustomMgmtCommandsTest(TransactionTestCase):
 
     fixtures = ["test_data.json"]
 
-    def test_create_data_package(self):
+    def test_create_and_load_data_package(self):
         err_out = StringIO()
         with TemporaryDirectory() as tmpdir:
             call_command("create_data_package", dir=tmpdir, stderr=err_out)
-            self.assertEqual(len(err_out.getvalue()), 0, "Errors output by command")
+            self.assertEqual(
+                len(err_out.getvalue()), 0, "Errors output by create command"
+            )
 
             with open(os.path.join(tmpdir, "data_all.json")) as da_fp:
                 json.load(da_fp)
@@ -31,6 +33,11 @@ class CustomMgmtCommandsTest(TransactionTestCase):
             # Check the output json lines file by parsing the first line
             with open(os.path.join(tmpdir, "recipients.jl")) as recipients_fp:
                 json.loads(recipients_fp.readline().strip())
+
+            call_command("load_data_package", tmpdir, stderr=err_out)
+            self.assertEqual(
+                len(err_out.getvalue()), 0, "Errors output by load command"
+            )
 
     def test_delete_datagetter_data(self):
         err_out = StringIO()


### PR DESCRIPTION
This command allows us to load a processed data package into the datastore that has been created by the datastore itself. This skips the lengthy additional_data stage.

The main use case for this is to be able to export data from the live datastore into a development instance in a timely way.