### PR TITLE
Upgrade certifi due to removal of vulnerable root CA.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ btrees==4.9.2
     #   zodb
 cached-property==1.5.2
     # via libcove
-certifi==2021.10.8
+certifi==2023.7.22
     # via
     #   datagetter
     #   requests
@@ -89,6 +89,7 @@ jsonref==0.2
 jsonschema==3.2.0
     # via
     #   datagetter
+    #   lib360dataquality
     #   libcove
 libcove==0.29.0
     # via lib360dataquality
@@ -109,7 +110,7 @@ persistent==4.7.0
     #   btrees
     #   datagetter
     #   zodb
-prometheus-client==0.7
+prometheus-client==0.7.0
     # via -r requirements.in
 psycopg2==2.8
     # via -r requirements.in
@@ -154,6 +155,7 @@ six==1.16.0
     #   django-prettyjson
     #   jsonschema
     #   python-dateutil
+    #   rfc3339-validator
     #   zodb
 sqlparse==0.4.3
     # via django

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -32,7 +32,7 @@ btrees==4.9.2
     #   zodb
 cached-property==1.5.2
     # via libcove
-certifi==2021.10.8
+certifi==2023.7.22
     # via
     #   datagetter
     #   requests
@@ -118,6 +118,7 @@ jsonref==0.2
 jsonschema==3.2.0
     # via
     #   datagetter
+    #   lib360dataquality
     #   libcove
 libcove==0.29.0
     # via lib360dataquality
@@ -148,7 +149,7 @@ persistent==4.7.0
     #   zodb
 platformdirs==2.6.0
     # via black
-prometheus-client==0.7
+prometheus-client==0.7.0
     # via -r requirements.in
 psycopg2==2.8
     # via -r requirements.in


### PR DESCRIPTION
See: 
* https://github.com/advisories/GHSA-xqr8-7jwr-rhp7
* https://opendataservices.plan.io/issues/42723

Upgraded using
```bash
  pip-compile --no-upgrade --upgrade-package 'certifi >= 2023.7.22' requirements.in
  pip-compile --no-upgrade --upgrade-package 'certifi >= 2023.7.22' requirements_dev.in
```
to only upgrade certifi.

Closes https://github.com/ThreeSixtyGiving/datastore/security/dependabot/40