### PR TITLE
requirements: Specify the version of the datagetter tool

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
--e git+https://github.com/ThreeSixtyGiving/datagetter.git#egg=datagetter
+-e git+https://github.com/ThreeSixtyGiving/datagetter.git@58fae3d2f93ea9477c1184dfa9f9cb83ab9f870d#egg=datagetter
 -e git+https://github.com/ThreeSixtyGiving/dataquality.git@main#egg=lib360dataquality
 Django<4.0
 djangorestframework==3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
--e git+https://github.com/ThreeSixtyGiving/datagetter.git#egg=datagetter
+-e git+https://github.com/ThreeSixtyGiving/datagetter.git@58fae3d2f93ea9477c1184dfa9f9cb83ab9f870d#egg=datagetter
     # via -r requirements.in
 -e git+https://github.com/ThreeSixtyGiving/dataquality.git@main#egg=lib360dataquality
     # via -r requirements.in

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements_dev.in
 #
--e git+https://github.com/ThreeSixtyGiving/datagetter.git#egg=datagetter
+-e git+https://github.com/ThreeSixtyGiving/datagetter.git@58fae3d2f93ea9477c1184dfa9f9cb83ab9f870d#egg=datagetter
     # via -r requirements.in
 -e git+https://github.com/ThreeSixtyGiving/dataquality.git@main#egg=lib360dataquality
     # via -r requirements.in


### PR DESCRIPTION
This helps deployment to know when this tool has been updated since we don't version the datagetter itself and keeps the version consistent across other instances of this application.