### PR TITLE
Add new org api to api index page

### DIFF
--- a/datastore/api/templates/api.html
+++ b/datastore/api/templates/api.html
@@ -9,6 +9,7 @@
         <li><a href="{% url "api:grantnav-updates" %}">{% url "api:grantnav-updates" %}</a></li>
         <li><a href="{% url "api:publishers" %}">{% url "api:publishers" %}</a></li>
         <li><a href="{% url "api:overview" %}">{% url "api:overview" %}</a></li>
+        <li><a href="{% url "api:organisation-list" %}">{% url "api:organisation-list" %}</a></li>
     </ul>
 </div>
 {% endblock %}


### PR DESCRIPTION
Add the now organisation-list url to the api index page, io make it easier to find.

Thought: The API's web UI (Swagger is it?) doesn't make it obvious that you can get detail about the listed organisations, but i vaguely remember seeing a UI that does make it obvious, maybe a box where you can paste the lookup key (org id)? Maybe DRF has an easy way to do that