### PR TITLE
db: add new GetterRun.latest() method

### DIFF
--- a/datastore/api/dashboard/api.py
+++ b/datastore/api/dashboard/api.py
@@ -47,7 +47,7 @@ class Publishers(generics.ListAPIView):
     ]
 
     def get_queryset(self):
-        return db.Publisher.objects.filter(getter_run=db.GetterRun.objects.last())
+        return db.Publisher.objects.filter(getter_run=db.GetterRun.latest())
 
 
 class Publisher(generics.RetrieveAPIView):
@@ -56,7 +56,7 @@ class Publisher(generics.RetrieveAPIView):
     serializer_class = serializers.PublisherSerializer
 
     def get_queryset(self):
-        return db.Publisher.objects.filter(getter_run=db.GetterRun.objects.last())
+        return db.Publisher.objects.filter(getter_run=db.GetterRun.latest())
 
 
 class Sources(generics.ListAPIView):
@@ -64,7 +64,7 @@ class Sources(generics.ListAPIView):
     #  pagination_class = CurrentLatestGrantsPaginator
 
     def get_queryset(self):
-        return db.SourceFile.objects.filter(getter_run=db.GetterRun.objects.last())
+        return db.SourceFile.objects.filter(getter_run=db.GetterRun.latest())
 
 
 class Overview(View):

--- a/datastore/api/experimental/api.py
+++ b/datastore/api/experimental/api.py
@@ -92,7 +92,7 @@ class OrganisationRetrieveView(generics.RetrieveAPIView):
         # is org a Publisher?
         try:
             publisher = publisher_queryset.filter(
-                org_id=org_id, getter_run=db.GetterRun.objects.last()
+                org_id=org_id, getter_run=db.GetterRun.latest()
             )[0]
         except IndexError:
             publisher = None

--- a/datastore/data_quality/quality_data.py
+++ b/datastore/data_quality/quality_data.py
@@ -368,7 +368,7 @@ class SourceFilesStats(object):
     def get_pc_quality_publishers(self):
         ret = {}
 
-        publishers = db.Publisher.objects.filter(getter_run=db.GetterRun.objects.last())
+        publishers = db.Publisher.objects.filter(getter_run=db.GetterRun.latest())
 
         total_publishers_all = publishers.count()
 

--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -130,6 +130,11 @@ class GetterRun(models.Model):
         self.archived = True
         self.save()
 
+    @classmethod
+    def latest(cls):
+        """Get the most recent GetterRun instance"""
+        return cls.objects.latest("datetime")
+
     def __str__(self):
         return "%s - %s" % (self.pk, self.datetime)
 

--- a/datastore/prometheus/views.py
+++ b/datastore/prometheus/views.py
@@ -67,7 +67,7 @@ class ServiceMetrics(View):
         TOTAL_PREVIOUS_LATEST_GRANTS.set(total_prev)
 
     def _total_datagetter_grants(self):
-        total = db.GetterRun.objects.last().grant_set.count()
+        total = db.GetterRun.latest().grant_set.count()
         TOTAL_DATAGETTER_GRANTS.set(total)
 
     def _total_num_sources_in_last_run(self):


### PR DESCRIPTION
Add a new GetterRun.latest() class method to easily fetch the most recent GetterRun object, and replace the previous uses of objects.last() which probably does return the most recent but theoretically isn't guaranteed to.

https://docs.djangoproject.com/en/3.2/ref/models/querysets/#django.db.models.query.QuerySet.latest
https://docs.djangoproject.com/en/3.2/ref/models/querysets/#django.db.models.query.QuerySet.last

Questions:
* Maybe we should call the method something a bit more descriptive like `latest_run()` or `latest_run_object()` instead of just `latest()`?
* Black-format-on-save strikes again, should I reinstate the removed whitespace or are we aiming to gradually reformat everything?