### PR TITLE
Smart GetterRun Retention

### DIFF
--- a/datastore/db/management/commands/delete_datagetter_data.py
+++ b/datastore/db/management/commands/delete_datagetter_data.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options.get("all-not-in-use"):
             options["getter_run_ids"] = set(options["getter_run_ids"]).union(
-                [gr.pk for gr in GetterRun.all_not_in_use()]
+                [gr.pk for gr in GetterRun.objects.not_in_use()]
             )
 
         if options.get("older_than_days"):

--- a/datastore/db/management/commands/delete_datagetter_data.py
+++ b/datastore/db/management/commands/delete_datagetter_data.py
@@ -35,6 +35,12 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
+            "--force-delete-in-use-data",
+            action="store_true",
+            help="Delete datagetter data even if it's in use by a latest best.",
+        )
+
+        parser.add_argument(
             "--update-latest-best",
             action="store_true",
             help="Update the latest best data set after deleting data",
@@ -65,6 +71,12 @@ class Command(BaseCommand):
             try:
                 confirm = "n"
                 getter_run = GetterRun.objects.get(pk=run)
+
+                if getter_run.is_in_use():
+                    print("In use  %s" % run)
+                    if not options["force_delete_in_use_data"]:
+                        print("Skipped %s" % run)
+                        continue
 
                 if not options["no_prompt"]:
                     confirm = input("Confirm delete '%s' y/n: " % run)

--- a/datastore/db/management/commands/delete_datagetter_data.py
+++ b/datastore/db/management/commands/delete_datagetter_data.py
@@ -25,13 +25,13 @@ class Command(BaseCommand):
         parser.add_argument(
             "--oldest",
             action="store_true",
-            help="Delete the oldest datagetter data",
+            help="Delete the oldest datagetter data run as long as it's not in use (unless overridden with --force-delete-in-use-data)",
         )
 
         parser.add_argument(
             "--older-than-days",
             type=int,
-            help="Delete datagetter data that's more than N days old.",
+            help="Delete datagetter data that's more than N days old and not in use (unless overridden with --force-delete-in-use-data)",
         )
 
         parser.add_argument(

--- a/datastore/db/management/commands/delete_datagetter_data.py
+++ b/datastore/db/management/commands/delete_datagetter_data.py
@@ -76,7 +76,8 @@ class Command(BaseCommand):
             )
 
         if len(options["getter_run_ids"]) == 0:
-            raise CommandError("No datagetter data specified")
+            print("No datagetter data to be deleted")
+            return
 
         for run in options["getter_run_ids"]:
             try:

--- a/datastore/db/management/commands/delete_datagetter_data.py
+++ b/datastore/db/management/commands/delete_datagetter_data.py
@@ -35,6 +35,12 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
+            "--all-not-in-use",
+            action="store_true",
+            help="Delete all datagetter data that's not in use",
+        )
+
+        parser.add_argument(
             "--force-delete-in-use-data",
             action="store_true",
             help="Delete datagetter data even if it's in use by a latest best.",
@@ -47,6 +53,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        if options.get("all-not-in-use"):
+            options["getter_run_ids"] = set(options["getter_run_ids"]).union(
+                [gr.pk for gr in GetterRun.all_not_in_use()]
+            )
+
         if options.get("older_than_days"):
             now_dt = datetime.now()
             older_than_dt = now_dt - timedelta(days=options["older_than_days"])

--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -145,6 +145,11 @@ class GetterRun(models.Model):
         """Return the QuerySet of all GetterRuns in-use by any Latest best."""
         return cls.objects.filter(sourcefile__latest__isnull=False).distinct()
 
+    @classmethod
+    def all_not_in_use(cls):
+        """Return the QuerySet of all GetterRuns NOT in-use by any Latest best. Inverse of all_in_use()."""
+        return cls.objects.exclude(sourcefile__latest__isnull=False).distinct()
+
 
 class SourceFile(models.Model):
     data = JSONField()

--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -137,8 +137,13 @@ class GetterRun(models.Model):
         return "%s - %s" % (self.pk, self.datetime)
 
     def is_in_use(self):
-        """Check if this GetterRun is included in any of the Latest best grantsets."""
-        return Latest.objects.all().filter(grant__getter_run__pk=self.pk).count() > 0
+        """Check if this GetterRun is included in any Latest best."""
+        return GetterRun.all_in_use().filter(pk=self.pk).exists()
+
+    @classmethod
+    def all_in_use(cls):
+        """Return the QuerySet of all GetterRuns in-use by any Latest best."""
+        return cls.objects.filter(sourcefile__latest__isnull=False).distinct()
 
 
 class SourceFile(models.Model):

--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -44,7 +44,6 @@ class Latest(models.Model):
         for failed_source in latest_getter.sourcefile_set.filter(
             models.Q(downloads=False) | models.Q(data_valid=False)
         ):
-
             failed_id = failed_source.data["identifier"]
             print(
                 "Processing the failed source %s\n%s" % (failed_id, failed_source.data)
@@ -58,7 +57,6 @@ class Latest(models.Model):
                 acceptable_license=True,
                 downloads=True,
             ).order_by("-getter_run"):
-
                 # Extra check make sure the source actually has grants.
                 # It isn't much good if not.
                 source_grant_count = candidate_replacement_source.grant_set.count()
@@ -137,6 +135,10 @@ class GetterRun(models.Model):
 
     def __str__(self):
         return "%s - %s" % (self.pk, self.datetime)
+
+    def is_in_use(self):
+        """Check if this GetterRun is included in any of the Latest best grantsets."""
+        return Latest.objects.all().filter(grant__getter_run__pk=self.pk).count() > 0
 
 
 class SourceFile(models.Model):
@@ -297,7 +299,6 @@ class Entity(models.Model):
 
 
 class Publisher(Entity):
-
     data = JSONField()
     quality = JSONField(null=True)
 

--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -113,7 +113,19 @@ class Latest(models.Model):
         return self.series
 
 
+class GetterRunManager(models.Manager):
+    def in_use(self):
+        """Return the QuerySet of all GetterRuns in-use by any Latest best."""
+        return self.filter(sourcefile__latest__isnull=False).distinct()
+
+    def not_in_use(self):
+        """Return the QuerySet of all GetterRuns NOT in-use by any Latest best. Inverse of in_use()."""
+        return self.exclude(sourcefile__latest__isnull=False).distinct()
+
+
 class GetterRun(models.Model):
+    objects = GetterRunManager()
+
     datetime = models.DateTimeField(default=timezone.now)
     archived = models.BooleanField(default=False)
 
@@ -138,17 +150,7 @@ class GetterRun(models.Model):
 
     def is_in_use(self):
         """Check if this GetterRun is included in any Latest best."""
-        return GetterRun.all_in_use().filter(pk=self.pk).exists()
-
-    @classmethod
-    def all_in_use(cls):
-        """Return the QuerySet of all GetterRuns in-use by any Latest best."""
-        return cls.objects.filter(sourcefile__latest__isnull=False).distinct()
-
-    @classmethod
-    def all_not_in_use(cls):
-        """Return the QuerySet of all GetterRuns NOT in-use by any Latest best. Inverse of all_in_use()."""
-        return cls.objects.exclude(sourcefile__latest__isnull=False).distinct()
+        return GetterRun.objects.in_use().filter(pk=self.pk).exists()
 
 
 class SourceFile(models.Model):

--- a/datastore/tests/test_commands.py
+++ b/datastore/tests/test_commands.py
@@ -42,10 +42,25 @@ class CustomMgmtCommandsTest(TransactionTestCase):
     def test_delete_datagetter_data(self):
         err_out = StringIO()
         call_command(
-            "delete_datagetter_data", "--oldest", "--no-prompt", stderr=err_out
+            "delete_datagetter_data",
+            "--oldest",
+            "--no-prompt",
+            "--force-delete-in-use-data",
+            stderr=err_out,
         )
         self.assertEqual(len(err_out.getvalue()), 0, "Errors output by command")
         self.assertEqual(db.GetterRun.objects.count(), 0)
+
+    def test_doesnt_delete_in_use_datagetter_data(self):
+        err_out = StringIO()
+        call_command(
+            "delete_datagetter_data",
+            "--oldest",
+            "--no-prompt",
+            stderr=err_out,
+        )
+        self.assertEqual(len(err_out.getvalue()), 0, "Errors output by command")
+        self.assertGreater(db.GetterRun.objects.count(), 0)
 
     def test_list_datagetter_runs(self):
         out = StringIO()

--- a/datastore/tests/test_commands.py
+++ b/datastore/tests/test_commands.py
@@ -52,7 +52,7 @@ class CustomMgmtCommandsTest(TransactionTestCase):
         self.assertEqual(db.GetterRun.objects.count(), 0)
 
     def test_doesnt_delete_in_use_datagetter_data_oldest(self):
-        in_use_pks_before = set(gr.pk for gr in db.GetterRun.all_in_use())
+        in_use_pks_before = set(gr.pk for gr in db.GetterRun.objects.in_use())
         err_out = StringIO()
         call_command(
             "delete_datagetter_data",
@@ -67,7 +67,7 @@ class CustomMgmtCommandsTest(TransactionTestCase):
         )
 
     def test_doesnt_delete_in_use_datagetter_data_all(self):
-        in_use_pks_before = set(gr.pk for gr in db.GetterRun.all_in_use())
+        in_use_pks_before = set(gr.pk for gr in db.GetterRun.objects.in_use())
         err_out = StringIO()
         call_command(
             "delete_datagetter_data",

--- a/datastore/tests/test_models.py
+++ b/datastore/tests/test_models.py
@@ -1,0 +1,18 @@
+from django.test import TransactionTestCase
+
+import db.models as db
+
+
+class GetterRunTest(TransactionTestCase):
+    fixtures = ["test_data.json"]
+
+    def test_in_use(self):
+        total_count = db.GetterRun.objects.all().count()
+        in_use_count = db.GetterRun.all_in_use().count()
+        not_in_use_count = db.GetterRun.all_not_in_use().count()
+
+        self.assertLessEqual(in_use_count, total_count)
+        self.assertLess(
+            not_in_use_count, total_count
+        )  # there should always be *some* in-use data
+        self.assertEqual(in_use_count + not_in_use_count, total_count)

--- a/datastore/tests/test_models.py
+++ b/datastore/tests/test_models.py
@@ -8,8 +8,8 @@ class GetterRunTest(TransactionTestCase):
 
     def test_in_use(self):
         total_count = db.GetterRun.objects.all().count()
-        in_use_count = db.GetterRun.all_in_use().count()
-        not_in_use_count = db.GetterRun.all_not_in_use().count()
+        in_use_count = db.GetterRun.objects.in_use().count()
+        not_in_use_count = db.GetterRun.objects.not_in_use().count()
 
         self.assertLessEqual(in_use_count, total_count)
         self.assertLess(

--- a/tools/data_run.sh
+++ b/tools/data_run.sh
@@ -81,7 +81,7 @@ TOTAL_RUNS=`./datastore/manage.py list_datagetter_runs --total`
 
 if [ $TOTAL_RUNS -gt $MAX_TOTAL_RUNS_IN_DB ]; then
     echo_stamp "Delete oldest datagetter data"
-    ./datastore/manage.py delete_datagetter_data --older-than-days 31 --no-prompt
+    ./datastore/manage.py delete_datagetter_data --all-not-in-use --older-than-days 90 --force-delete-in-use-data --no-prompt
 fi
 
 echo_stamp "Deleting old GrantNav packages"

--- a/tools/data_run.sh
+++ b/tools/data_run.sh
@@ -81,7 +81,7 @@ TOTAL_RUNS=`./datastore/manage.py list_datagetter_runs --total`
 
 if [ $TOTAL_RUNS -gt $MAX_TOTAL_RUNS_IN_DB ]; then
     echo_stamp "Delete oldest datagetter data"
-    ./datastore/manage.py delete_datagetter_data --oldest --no-prompt
+    ./datastore/manage.py delete_datagetter_data --older-than-days 31 --no-prompt
 fi
 
 echo_stamp "Deleting old GrantNav packages"


### PR DESCRIPTION
We'd like to save storage space and extend data retention time by intelligently retaining old GetterRun datasets if they are still in use.

This PR:
* Adds a `GetterRun.is_in_use()` shortcut method to check if a GetterRun instance is in use by any Latest instance.
* by default, prevents deleting DataGetter instance/data if it's still in use by a Latest instance.
* Adds a `--force-delete-in-use-data` flag to `manage.py delete_datagetter_data` to allow deleting data that's still in use anyway (as per current behaviour).
* Adds a `--older-than-days` flag to `manage.py delete_datagetter_data`, to allow us to delete all not-in-use GetterRuns older than N days.

I've added the `--older-than-days` flag because I figured just deleting the single oldest GetterRun could cause us to store a lot of unnecessary data, because if the oldest one is in use, it'll not delete it. Then if the oldest is say, a year old, the existing behaviour with `--oldest` will never delete anything newer than that either, even if e.g. 99% of runs are unused.

So I guess, say we want to retain the last 7 days fully, plus anything older still in use, we could replace the existing `--oldest` with `--older-than-days 7`

Questions:
 * How long should we retain all data for? Keep it at the existing 31-ish days, or go down to say a week?
 * Do we want to add another command to `data_run.sh` to force-delete really old data, e.g. `manage.py delete_datagetter_data --no-prompt --older-than-days 366 --force-delete-in-use-data` to fully get rid of anything older than a year

Related to ODSC support ticket 44487.

Further note:

After discussion we've decided to not retain any not-in-use data, and retain in-use data for 90 days. This PR also adds `--all-not-in-use` flag and updates the command as run to implement this policy.