### PR TITLE
Update settings_dev to enable logging and stable sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ $ pip install -r requirements.txt
 ## Run the dev server
 
 ```
+$ export DJANGO_SETTINGS_MODULE=settings.settings_dev
 $ manage.py migrate
 $ manage.py createsuperuser
 $ manage.py runserver

--- a/datastore/settings/settings_dev.py
+++ b/datastore/settings/settings_dev.py
@@ -1,10 +1,7 @@
 # flake8: noqa
-<<<<<<< Updated upstream
-=======
 import os
 import socket
 import hashlib
->>>>>>> Stashed changes
 from settings.settings import *
 
 # This adds the CORS header to API calls for the django dev server
@@ -29,3 +26,27 @@ MIDDLEWARE = MIDDLEWARE + [
 ]
 
 CORS_ORIGIN_ALLOW_ALL = True
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "simple": {
+            "format": "{levelname} [{module}] {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["console"],
+            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+            "formatter": "simple",
+            "propagate": True,
+        },
+    },
+}

--- a/datastore/settings/settings_dev.py
+++ b/datastore/settings/settings_dev.py
@@ -1,9 +1,26 @@
 # flake8: noqa
+<<<<<<< Updated upstream
+=======
+import os
+import socket
+import hashlib
+>>>>>>> Stashed changes
 from settings.settings import *
 
 # This adds the CORS header to API calls for the django dev server
 
 DEBUG = True
+
+
+# Use combo of hostname+cwd to generate secret key, so that it's stable across reloads
+def get_secret_key():
+    secret_key_m = hashlib.sha256()
+    secret_key_m.update(socket.gethostname().encode())
+    secret_key_m.update(os.getcwd().encode())
+    return secret_key_m.digest()
+
+
+SECRET_KEY = get_secret_key()
 
 INSTALLED_APPS = INSTALLED_APPS + ["corsheaders"]
 


### PR DESCRIPTION
This PR updates local dev settings (usable with `export DJANGO_SETTINGS_MODULE=settings.settings_dev`):
* Adds a non-random SECRET_KEY so that login sessions (i.e. to django admin) won't be constantly destroyed by the dev server auto-reloading.
* Adds logging config so that `logger....` methods will output log info to the console (same as print).