### PR TITLE
db: Improve list_datagetter_runs command

### DIFF
--- a/datastore/db/management/commands/list_datagetter_runs.py
+++ b/datastore/db/management/commands/list_datagetter_runs.py
@@ -15,9 +15,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if options.get("total"):
-            print("%s" % GetterRun.objects.count(), file=self.stdout)
+            self.stdout.write("%s" % GetterRun.objects.count())
             return
 
-        print("id | datetime")
+        self.stdout.write("id  | datetime                         | in_use")
         for run in GetterRun.objects.all():
-            print("%s | %s" % (run.pk, str(run)), file=self.stdout)
+            self.stdout.write(
+                "{:<3} | {} | {}".format(run.pk, run.datetime, run.is_in_use())
+            )

--- a/datastore/tests/test_commands.py
+++ b/datastore/tests/test_commands.py
@@ -108,7 +108,7 @@ class CustomMgmtCommandsTest(TransactionTestCase):
         out = StringIO()
         err_out = StringIO()
         call_command("list_datagetter_runs", stdout=out, stderr=err_out)
-        self.assertIn("1 |", out.getvalue())
+        self.assertIn("1   |", out.getvalue())
         self.assertEqual(len(err_out.getvalue()), 0, "Errors output by command")
 
     def test_set_status(self):


### PR DESCRIPTION
Nicer output.
Add the in_use status of each getter run.

e.g.

```
> ./manage.py list_datagetter_runs

id  | datetime                         | in_use
6   | 2023-10-31 14:40:06.189967+00:00 | False
7   | 2023-10-31 14:40:17.608123+00:00 | False
8   | 2023-10-31 14:58:00.374404+00:00 | False
9   | 2023-10-31 14:59:59.459714+00:00 | True
10  | 2023-11-23 12:34:30.694581+00:00 | True

```