### PR TITLE
tests: Don't throttle requests when testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
     - run: coverage run --source='./datastore' ./datastore/manage.py test -v 3 tests
       env:
         DATA_RUN_PID_FILE: datarunpidfile.pid
+        DJANGO_SETTINGS_MODULE: settings.settings_test
     - name: Verify it compiles and is installed
       run: datagetter.py --help
 

--- a/datastore/settings/settings_dev.py
+++ b/datastore/settings/settings_dev.py
@@ -2,7 +2,8 @@
 import os
 import socket
 import hashlib
-from settings.settings import *
+from settings.settings import *  # noqa F401, F403
+from settings.settings import REST_FRAMEWORK
 
 # This adds the CORS header to API calls for the django dev server
 
@@ -50,3 +51,7 @@ LOGGING = {
         },
     },
 }
+
+# Don't throttle in dev environment
+REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = []
+REST_FRAMEWORK["DEFAULT_THROTTLE_RATE"] = {}

--- a/datastore/settings/settings_test.py
+++ b/datastore/settings/settings_test.py
@@ -1,0 +1,6 @@
+from settings.settings import *  # noqa F401, F403
+from settings.settings import REST_FRAMEWORK
+
+# Don't throttle in test environment
+REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = []
+REST_FRAMEWORK["DEFAULT_THROTTLE_RATE"] = {}


### PR DESCRIPTION
This PR:
* Creates a new settings file `settings/settings_test.py` which disables throttling
* Configures CI tests to use `settings.settings_test`
* Disables throttling in `settings_dev.py` too

I've tested this by cherry-picking it into the API 3 PR, which previously failed tests due to throttle limits https://github.com/ThreeSixtyGiving/datastore/actions/runs/7961604913/job/21733199927?pr=181 