### PR TITLE
API: Raise 404 on Org Views when doesn't exist, and other fixes

### DIFF
--- a/datastore/api/experimental/api.py
+++ b/datastore/api/experimental/api.py
@@ -3,7 +3,7 @@ from rest_framework import filters, generics
 from rest_framework.pagination import LimitOffsetPagination
 
 import db.models as db
-from . import serializers
+from api.experimental import serializers
 
 
 class CurrentLatestGrantsPaginator(LimitOffsetPagination):

--- a/datastore/api/org/api.py
+++ b/datastore/api/org/api.py
@@ -72,14 +72,15 @@ class OrganisationDetailView(generics.RetrieveAPIView):
             db.Publisher.objects.filter(getter_run__in=db.GetterRun.objects.in_use())
         )
 
-        organisation = models.Organisation.get(
-            org_id,
-            funder_queryset=funder_queryset,
-            recipient_queryset=recipient_queryset,
-            publisher_queryset=publisher_queryset,
-        )
+        try:
+            organisation = models.Organisation.get(
+                org_id,
+                funder_queryset=funder_queryset,
+                recipient_queryset=recipient_queryset,
+                publisher_queryset=publisher_queryset,
+            )
 
-        if not organisation:
+        except models.Organisation.DoesNotExist:
             raise Http404
 
         return organisation

--- a/datastore/api/org/api.py
+++ b/datastore/api/org/api.py
@@ -1,5 +1,6 @@
-from django.http import Http404
 import django_filters.rest_framework
+import rest_framework.exceptions
+from django.http import Http404
 from rest_framework import generics
 from rest_framework.pagination import LimitOffsetPagination
 
@@ -101,6 +102,11 @@ class OrganisationGrantsMadeView(generics.ListAPIView):
 
     def get_queryset(self):
         org_id = self.kwargs.get("org_id")
+
+        # Raise 404 if the Org doesn't exist
+        if not models.Organisation.exists(org_id):
+            raise rest_framework.exceptions.NotFound()
+
         return db.Latest.grants().filter(
             data__fundingOrganization__contains=[{"id": org_id}]
         )
@@ -119,6 +125,11 @@ class OrganisationGrantsReceivedView(generics.ListAPIView):
 
     def get_queryset(self):
         org_id = self.kwargs.get("org_id")
+
+        # Raise 404 if the Org doesn't exist
+        if not models.Organisation.exists(org_id):
+            raise rest_framework.exceptions.NotFound()
+
         return db.Latest.grants().filter(
             data__recipientOrganization__contains=[{"id": org_id}]
         )

--- a/datastore/api/org/api.py
+++ b/datastore/api/org/api.py
@@ -5,8 +5,8 @@ from rest_framework import generics
 from rest_framework.pagination import LimitOffsetPagination
 
 import db.models as db
-from . import models
-from . import serializers
+from api.org import models
+from api.org import serializers
 
 
 class OrganisationsPagination(LimitOffsetPagination):

--- a/datastore/api/org/models.py
+++ b/datastore/api/org/models.py
@@ -43,6 +43,28 @@ class Organisation:
         pass
 
     @staticmethod
+    def exists(
+        org_id: str,
+        funder_queryset: Optional[QuerySet[db.Funder]] = None,
+        recipient_queryset: Optional[QuerySet[db.Recipient]] = None,
+        publisher_queryset: Optional[QuerySet[db.Publisher]] = None,
+    ) -> bool:
+        """
+        Checks if an Organisation with this Org ID exists, returns True if exists, False if not.
+        """
+        try:
+            _ = Organisation.get(
+                org_id=org_id,
+                funder_queryset=funder_queryset,
+                recipient_queryset=recipient_queryset,
+                publisher_queryset=publisher_queryset,
+            )
+        except Organisation.DoesNotExist:
+            return False
+
+        return True
+
+    @staticmethod
     def get(
         org_id: str,
         funder_queryset: Optional[QuerySet[db.Funder]] = None,

--- a/datastore/api/org/serializers.py
+++ b/datastore/api/org/serializers.py
@@ -7,7 +7,7 @@ from drf_spectacular.types import OpenApiTypes
 from rest_framework_dataclasses.serializers import DataclassSerializer
 
 import db.models as db
-from . import models
+from api.org import models
 
 
 class OrganisationRefSerializer(DataclassSerializer):

--- a/datastore/tests/test_org_api.py
+++ b/datastore/tests/test_org_api.py
@@ -398,3 +398,34 @@ class OrgAPITestCase(TestCase):
                 }
 
                 self.assertIn(expected_entry, data["results"])
+
+    #
+    # Non-existent Org
+    #
+    def test_non_existent_org_detail(self):
+        """Check for 404 on non-existent Org detail"""
+        response = self.client.get(
+            reverse_lazy("api:organisation-detail", kwargs={"org_id": "XE-DOESNTEXIST"})
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_non_existent_org_grants_made(self):
+        """Check for 404 on non-existent Org grants made"""
+        response = self.client.get(
+            reverse_lazy(
+                "api:organisation-grants-made", kwargs={"org_id": "XE-DOESNTEXIST"}
+            )
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_non_existent_org_grants_received(self):
+        """Check for 404 on non-existent Org grants received"""
+        response = self.client.get(
+            reverse_lazy(
+                "api:organisation-grants-received", kwargs={"org_id": "XE-DOESNTEXIST"}
+            )
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/datastore/tests/test_org_api.py
+++ b/datastore/tests/test_org_api.py
@@ -311,7 +311,7 @@ class OrgAPITestCase(TestCase):
     def test_recipient_grants_made(self):
         """A Recipient-only Org should not make any grants."""
         data = self.client.get(
-            f"/api/experimental/org/{self.recipient_grant_id}/grants_made/",
+            f"/api/experimental/org/{self.recipient_org_id}/grants_made/",
             headers={"accept": "application/json"},
         ).json()
 

--- a/datastore/tests/test_org_api.py
+++ b/datastore/tests/test_org_api.py
@@ -405,7 +405,9 @@ class OrgAPITestCase(TestCase):
     def test_non_existent_org_detail(self):
         """Check for 404 on non-existent Org detail"""
         response = self.client.get(
-            reverse_lazy("api:organisation-detail", kwargs={"org_id": "XE-DOESNTEXIST"})
+            reverse_lazy(
+                "api:organisation-detail", kwargs={"org_id": "XE-EXAMPLE-DOESNTEXIST"}
+            )
         )
 
         self.assertEqual(response.status_code, 404)
@@ -414,7 +416,8 @@ class OrgAPITestCase(TestCase):
         """Check for 404 on non-existent Org grants made"""
         response = self.client.get(
             reverse_lazy(
-                "api:organisation-grants-made", kwargs={"org_id": "XE-DOESNTEXIST"}
+                "api:organisation-grants-made",
+                kwargs={"org_id": "XE-EXAMPLE-DOESNTEXIST"},
             )
         )
 
@@ -424,7 +427,8 @@ class OrgAPITestCase(TestCase):
         """Check for 404 on non-existent Org grants received"""
         response = self.client.get(
             reverse_lazy(
-                "api:organisation-grants-received", kwargs={"org_id": "XE-DOESNTEXIST"}
+                "api:organisation-grants-received",
+                kwargs={"org_id": "XE-EXAMPLE-DOESNTEXIST"},
             )
         )
 

--- a/datastore/tests/test_org_api_models.py
+++ b/datastore/tests/test_org_api_models.py
@@ -1,0 +1,13 @@
+from django.test import TransactionTestCase
+
+from api.org.models import Organisation
+
+
+class TestOrganisationModel(TransactionTestCase):
+    fixtures = ["test_data.json"]
+
+    def test_org_exists(self):
+        self.assertTrue(Organisation.exists("360G-example-a"))
+
+    def test_org_not_exists(self):
+        self.assertFalse(Organisation.exists("XE-DOESNTEXIST"))

--- a/datastore/tests/test_org_api_models.py
+++ b/datastore/tests/test_org_api_models.py
@@ -10,4 +10,4 @@ class TestOrganisationModel(TransactionTestCase):
         self.assertTrue(Organisation.exists("360G-example-a"))
 
     def test_org_not_exists(self):
-        self.assertFalse(Organisation.exists("XE-DOESNTEXIST"))
+        self.assertFalse(Organisation.exists("XE-EXAMPLE-DOESNTEXIST"))

--- a/datastore/tests/test_org_api_models.py
+++ b/datastore/tests/test_org_api_models.py
@@ -6,8 +6,47 @@ from api.org.models import Organisation
 class TestOrganisationModel(TransactionTestCase):
     fixtures = ["test_data.json"]
 
+    funder_org_id = "GB-example-b"
+    funder_org_name = "Funding for examples"
+
+    recipient_org_id = "360G-example-a"
+    recipient_org_name = "Receive an example grant"
+
+    publisher_org_id = "GB-CHC-9000009"
+    publisher_org_name = "The Heex1ieKu0 publisher"
+
     def test_org_exists(self):
-        self.assertTrue(Organisation.exists("360G-example-a"))
+        self.assertTrue(Organisation.exists(self.funder_org_id))
+        self.assertTrue(Organisation.exists(self.recipient_org_id))
+        self.assertTrue(Organisation.exists(self.publisher_org_id))
 
     def test_org_not_exists(self):
         self.assertFalse(Organisation.exists("XE-EXAMPLE-DOESNTEXIST"))
+
+    def test_funder(self):
+        org = Organisation.get(self.funder_org_id)
+        self.assertEqual(org.org_id, self.funder_org_id)
+        self.assertEqual(org.name, self.funder_org_name)
+        self.assertIsNotNone(org.funder)
+        self.assertIsNone(org.recipient)
+        self.assertIsNone(org.publisher)
+
+    def test_recipient(self):
+        org = Organisation.get(self.recipient_org_id)
+        self.assertEqual(org.org_id, self.recipient_org_id)
+        self.assertEqual(org.name, self.recipient_org_name)
+        self.assertIsNone(org.funder)
+        self.assertIsNotNone(org.recipient)
+        self.assertIsNone(org.publisher)
+
+    def test_publisher(self):
+        org = Organisation.get(self.publisher_org_id)
+        self.assertEqual(org.org_id, self.publisher_org_id)
+        self.assertEqual(org.name, self.publisher_org_name)
+        self.assertIsNone(org.funder)
+        self.assertIsNone(org.recipient)
+        self.assertIsNotNone(org.publisher)
+
+    def test_non_existent_org(self):
+        with self.assertRaises(Organisation.DoesNotExist):
+            _ = Organisation.get("XE-EXAMPLE-DOESNOTEXIST")


### PR DESCRIPTION
This PR is a result of review change requests from #178, #179, #181 and #183, but collates the changes here to avoid complicated rebasing.

This PR:
* Fixes a bug in the OrgDetailView, so that it will 404 when an Org is not found.
* Changes 404 behaviour of the org grants views to match the detail view, i.e. if the Org doesn't exist in DB, then 404 (instead of returning an empty list).
* Adds an `exists()` method to the `Organisation` pseudo-model to facilitate this feature, plus tests.
* Adds tests for endpoint behaviour when a non-existent Org ID is given.
* Adds tests for `Organisation.get()`
* Change relative imports for absolute imports