### PR TITLE
dev: Add Django Debug Toolbar

### DIFF
--- a/datastore/settings/settings.py
+++ b/datastore/settings/settings.py
@@ -37,7 +37,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-
 # Application definition
 
 INSTALLED_APPS = [

--- a/datastore/settings/settings_dev.py
+++ b/datastore/settings/settings_dev.py
@@ -20,13 +20,22 @@ def get_secret_key():
 
 SECRET_KEY = get_secret_key()
 
-INSTALLED_APPS = INSTALLED_APPS + ["corsheaders"]
+INSTALLED_APPS = INSTALLED_APPS + ["corsheaders", "debug_toolbar"]
 
-MIDDLEWARE = MIDDLEWARE + [
-    "corsheaders.middleware.CorsMiddleware",
-]
+MIDDLEWARE = (
+    ["debug_toolbar.middleware.DebugToolbarMiddleware"]
+    + MIDDLEWARE
+    + ["corsheaders.middleware.CorsMiddleware"]
+)
 
 CORS_ORIGIN_ALLOW_ALL = True
+
+# Django Debug Toolbar will only appear to users on internal IPs listed here
+INTERNAL_IPS = [
+    "127.0.0.1",
+    "::1",
+]
+
 
 LOGGING = {
     "version": 1,

--- a/datastore/urls.py
+++ b/datastore/urls.py
@@ -13,8 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import include, path
+from django.conf import settings
 
 # This is the root urlconf
 
@@ -28,3 +30,6 @@ urlpatterns = [
     ),
     path("admin/", admin.site.urls, name="admin"),
 ]
+
+if settings.DEBUG:
+    urlpatterns += [path("__debug__/", include("debug_toolbar.urls"))]

--- a/requirements.in
+++ b/requirements.in
@@ -9,3 +9,4 @@ prometheus_client==0.7
 django-environ
 drf-spectacular>=0.27,<0.28
 djangorestframework-dataclasses>=1.3.1,<2
+django-debug-toolbar>=4.3,<4.4 # When upgrading DDT, check that newer versions still support Django 3.2.

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,11 +47,14 @@ defusedxml==0.7.1
 django==3.2.16
     # via
     #   -r requirements.in
+    #   django-debug-toolbar
     #   django-filter
     #   django-prettyjson
     #   djangorestframework
     #   djangorestframework-dataclasses
     #   drf-spectacular
+django-debug-toolbar==4.3.0
+    # via -r requirements.in
 django-environ==0.9.0
     # via -r requirements.in
 django-filter==22.1
@@ -122,7 +125,7 @@ persistent==4.7.0
     #   btrees
     #   datagetter
     #   zodb
-prometheus-client==0.7
+prometheus-client==0.7.0
     # via -r requirements.in
 psycopg2==2.8
     # via -r requirements.in
@@ -170,9 +173,12 @@ six==1.16.0
     #   django-prettyjson
     #   jsonschema
     #   python-dateutil
+    #   rfc3339-validator
     #   zodb
 sqlparse==0.4.3
-    # via django
+    # via
+    #   django
+    #   django-debug-toolbar
 standardjson==0.3.1
     # via django-prettyjson
 strict-rfc3339==0.7

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -65,6 +65,7 @@ django==3.2.16
     # via
     #   -r requirements.in
     #   django-cors-headers
+    #   django-debug-toolbar
     #   django-filter
     #   django-prettyjson
     #   djangorestframework
@@ -72,6 +73,8 @@ django==3.2.16
     #   drf-spectacular
 django-cors-headers==3.13.0
     # via -r requirements_dev.in
+django-debug-toolbar==4.3.0
+    # via -r requirements.in
 django-environ==0.9.0
     # via -r requirements.in
 django-filter==22.1
@@ -161,7 +164,7 @@ persistent==4.7.0
     #   zodb
 platformdirs==2.6.0
     # via black
-prometheus-client==0.7
+prometheus-client==0.7.0
     # via -r requirements.in
 psycopg2==2.8
     # via -r requirements.in
@@ -228,7 +231,9 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
     # via trio
 sqlparse==0.4.3
-    # via django
+    # via
+    #   django
+    #   django-debug-toolbar
 standardjson==0.3.1
     # via django-prettyjson
 strict-rfc3339==0.7


### PR DESCRIPTION
PR MOVED TO https://github.com/ThreeSixtyGiving/datastore/pull/195
because GitHub doesn't want to re-open this one.

Add the Django Debug Toolbar to the project, in particular to make debugging SQL queries easier.