### PR TITLE
API: Update URLs for v1 launch

### DIFF
--- a/datastore/api/org/api_schema.py
+++ b/datastore/api/org/api_schema.py
@@ -25,7 +25,7 @@ def only_include_org_api_endpoints(endpoints):
 
 
 SPECTACULAR_SETTINGS = {
-    "TITLE": "360G Organisation Grants API",
+    "TITLE": "360 Giving Organisation Grants API",
     "DESCRIPTION": "Describe grants made and recieved by organisations.",
     "VERSION": "0.0.1",
     "COMPONENT_SPLIT_REQUEST": True,

--- a/datastore/api/org/api_schema.py
+++ b/datastore/api/org/api_schema.py
@@ -3,11 +3,10 @@ from drf_spectacular.views import SpectacularAPIView
 
 INCLUDE_PATHS = set(
     [
-        "/api/experimental/org/{org_id}/grants_made/",
-        "/api/experimental/org/{org_id}/grants_received/",
-        "/api/experimental/org/{org_id}/",
-        "/api/experimental/org/",
-        "/api/experimental/grant/{grant_id}/",
+        "/api/v1/org/{org_id}/grants_made/",
+        "/api/v1/org/{org_id}/grants_received/",
+        "/api/v1/org/{org_id}/",
+        "/api/v1/org/",
     ]
 )
 
@@ -27,7 +26,7 @@ def only_include_org_api_endpoints(endpoints):
 SPECTACULAR_SETTINGS = {
     "TITLE": "360 Giving Organisation Grants API",
     "DESCRIPTION": "Describe grants made and recieved by organisations.",
-    "VERSION": "0.0.1",
+    "VERSION": "1.0.0",
     "COMPONENT_SPLIT_REQUEST": True,
     "PREPROCESSING_HOOKS": [__name__ + "." + only_include_org_api_endpoints.__name__],
 }

--- a/datastore/api/urls.py
+++ b/datastore/api/urls.py
@@ -54,40 +54,41 @@ urlpatterns = [
         api.experimental.api.CurrentLatestGrants.as_view(),
         name="current-latest-grants",
     ),
+    # Public API
     path(
-        "experimental/org/<path:org_id>/grants_made/",
+        "v1/org/<path:org_id>/grants_made/",
         api.org.api.OrganisationGrantsMadeView.as_view(),
         name="organisation-grants-made",
     ),
     path(
-        "experimental/org/<path:org_id>/grants_received/",
+        "v1/org/<path:org_id>/grants_received/",
         api.org.api.OrganisationGrantsReceivedView.as_view(),
         name="organisation-grants-received",
     ),
     path(
-        "experimental/org/<path:org_id>/",
+        "v1/org/<path:org_id>/",
         api.org.api.OrganisationDetailView.as_view(),
         name="organisation-detail",
     ),
     path(
-        "experimental/org/",
+        "v1/org/",
         api.org.api.OrganisationListView.as_view(),
         name="organisation-list",
     ),
     # Schema UI
     path(
-        "experimental/schema/",
+        "v1/schema/",
         api.org.api_schema.APISchemaView.as_view(),
         name="schema",
     ),
     # Optional UI:
     path(
-        "experimental/swagger-ui/",
+        "v1/swagger-ui/",
         SpectacularSwaggerView.as_view(url_name="api:schema"),
         name="swagger-ui",
     ),
     path(
-        "experimental/redoc/",
+        "v1/redoc/",
         SpectacularRedocView.as_view(url_name="api:schema"),
         name="redoc",
     ),

--- a/datastore/tests/test_org_api.py
+++ b/datastore/tests/test_org_api.py
@@ -77,7 +77,7 @@ class OrgAPITestCase(TestCase):
         }
 
         data = self.client.get(
-            f"/api/experimental/org/{self.funder_org_id}/",
+            f"/api/v1/org/{self.funder_org_id}/",
             headers={"accept": "application/json"},
         ).json()
 
@@ -87,7 +87,7 @@ class OrgAPITestCase(TestCase):
         """A Funder-only Org should have received no grants."""
 
         data = self.client.get(
-            f"/api/experimental/org/{self.funder_org_id}/grants_received/",
+            f"/api/v1/org/{self.funder_org_id}/grants_received/",
             headers={"accept": "application/json"},
         ).json()
 
@@ -166,7 +166,7 @@ class OrgAPITestCase(TestCase):
         }
 
         data = self.client.get(
-            f"/api/experimental/org/{self.funder_org_id}/grants_made/",
+            f"/api/v1/org/{self.funder_org_id}/grants_made/",
             headers={"accept": "application/json"},
         ).json()
 
@@ -221,7 +221,7 @@ class OrgAPITestCase(TestCase):
         }
 
         data = self.client.get(
-            f"/api/experimental/org/{self.recipient_org_id}/",
+            f"/api/v1/org/{self.recipient_org_id}/",
             headers={"accept": "application/json"},
         ).json()
 
@@ -297,7 +297,7 @@ class OrgAPITestCase(TestCase):
         }
 
         data = self.client.get(
-            f"/api/experimental/org/{self.recipient_org_id}/grants_received/",
+            f"/api/v1/org/{self.recipient_org_id}/grants_received/",
             headers={"accept": "application/json"},
         ).json()
 
@@ -311,7 +311,7 @@ class OrgAPITestCase(TestCase):
     def test_recipient_grants_made(self):
         """A Recipient-only Org should not make any grants."""
         data = self.client.get(
-            f"/api/experimental/org/{self.recipient_org_id}/grants_made/",
+            f"/api/v1/org/{self.recipient_org_id}/grants_made/",
             headers={"accept": "application/json"},
         ).json()
 
@@ -346,7 +346,7 @@ class OrgAPITestCase(TestCase):
         }
 
         data = self.client.get(
-            f"/api/experimental/org/{self.publisher_org_id}/",
+            f"/api/v1/org/{self.publisher_org_id}/",
             headers={"accept": "application/json"},
         ).json()
 
@@ -355,7 +355,7 @@ class OrgAPITestCase(TestCase):
     def test_publisher_grants_made(self):
         """A Publisher-only Org should have made no grants."""
         data = self.client.get(
-            f"/api/experimental/org/{self.publisher_org_id}/grants_received/",
+            f"/api/v1/org/{self.publisher_org_id}/grants_received/",
             headers={"accept": "application/json"},
         ).json()
 
@@ -366,7 +366,7 @@ class OrgAPITestCase(TestCase):
         """A Publisher-only Org should have received no grants."""
 
         data = self.client.get(
-            f"/api/experimental/org/{self.publisher_org_id}/grants_received/",
+            f"/api/v1/org/{self.publisher_org_id}/grants_received/",
             headers={"accept": "application/json"},
         ).json()
 
@@ -380,7 +380,7 @@ class OrgAPITestCase(TestCase):
     def test_org_list(self):
         """Check that the given Org is in the Org List"""
         data = self.client.get(
-            "/api/experimental/org/",
+            "/api/v1/org/",
             headers={"accept": "application/json"},
         ).json()
 


### PR DESCRIPTION
This PR swaps out `experimental` for `v1` in Public API URLs.