### PR TITLE
api: Add data_license to Grants

### DIFF
--- a/datastore/api/org/api.py
+++ b/datastore/api/org/api.py
@@ -113,9 +113,11 @@ class OrganisationGrantsMadeView(generics.ListAPIView):
         if not models.Organisation.exists(org_id):
             raise rest_framework.exceptions.NotFound()
 
-        return db.Grant.objects.filter(
-            source_file__latest__series=db.Latest.CURRENT
-        ).filter(funding_org_ids__contains=[org_id])
+        return (
+            db.Grant.objects.filter(source_file__latest__series=db.Latest.CURRENT)
+            .filter(funding_org_ids__contains=[org_id])
+            .select_related("source_file")
+        )
 
 
 class OrganisationGrantsReceivedView(generics.ListAPIView):
@@ -136,6 +138,8 @@ class OrganisationGrantsReceivedView(generics.ListAPIView):
         if not models.Organisation.exists(org_id):
             raise rest_framework.exceptions.NotFound()
 
-        return db.Grant.objects.filter(
-            source_file__latest__series=db.Latest.CURRENT
-        ).filter(recipient_org_ids__contains=[org_id])
+        return (
+            db.Grant.objects.filter(source_file__latest__series=db.Latest.CURRENT)
+            .filter(recipient_org_ids__contains=[org_id])
+            .select_related("source_file")
+        )

--- a/datastore/api/org/models.py
+++ b/datastore/api/org/models.py
@@ -139,3 +139,9 @@ class Organisation:
             recipient=recipient,
             publisher=publisher,
         )
+
+
+@dataclass
+class GrantLicense:
+    url: str
+    name: str

--- a/datastore/api/org/serializers.py
+++ b/datastore/api/org/serializers.py
@@ -119,16 +119,41 @@ class GrantDataField(serializers.JSONField):
     pass
 
 
+class GrantLicenseSerializer(DataclassSerializer):
+    class Meta:
+        dataclass = models.GrantLicense
+
+    url = serializers.URLField()
+
+
 class GrantSerializer(serializers.ModelSerializer):
     class Meta:
         model = db.Grant
-        fields = ["grant_id", "data", "publisher", "recipients", "funders"]
+        fields = [
+            "grant_id",
+            "data",
+            "data_license",
+            "publisher",
+            "recipients",
+            "funders",
+        ]
 
     data = GrantDataField()
+
+    data_license = serializers.SerializerMethodField()
 
     publisher = serializers.SerializerMethodField()
     recipients = serializers.SerializerMethodField()
     funders = serializers.SerializerMethodField()
+
+    @extend_schema_field(GrantLicenseSerializer)
+    def get_data_license(self, grant):
+        return GrantLicenseSerializer(
+            models.GrantLicense(
+                url=grant.source_file.data.get("license"),
+                name=grant.source_file.data.get("license_name"),
+            )
+        ).data
 
     @extend_schema_field(OrganisationRefSerializer)
     def get_publisher(self, grant):

--- a/datastore/tests/test_org_api.py
+++ b/datastore/tests/test_org_api.py
@@ -137,6 +137,10 @@ class OrgAPITestCase(TestCase):
                     }
                 ],
             },
+            "data_license": {
+                "url": "https://creativecommons.org/licenses/by/4.0/",
+                "name": "Creative Commons Attribution 4.0",
+            },
             "publisher": {
                 "self": "http://testserver"
                 + reverse_lazy(
@@ -267,6 +271,10 @@ class OrgAPITestCase(TestCase):
                         "addressLocality": "LONDON",
                     }
                 ],
+            },
+            "data_license": {
+                "url": "https://creativecommons.org/licenses/by/4.0/",
+                "name": "Creative Commons Attribution 4.0",
             },
             "publisher": {
                 "self": "http://testserver"


### PR DESCRIPTION
This PR adds License info to each Grant in the Public API's GrantsReceviedView and GrantsMadeView.

For each grant, alongside `data`, an extra `data_license` field is added, e.g.:
```json
"data": { /* ... */ },
"data_license": {
    "url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
    "name": "Open Government Licence 3.0 (United Kingdom)"
},
```

where the license info is pulled from the related SourceFile.