### PR TITLE
db: Exclude Grants with Unacceptable Data

### DIFF
--- a/datastore/db/management/commands/load_data_package.py
+++ b/datastore/db/management/commands/load_data_package.py
@@ -1,10 +1,14 @@
 import copy
+import logging
+import json
 
 import db.models as db
 
 from db.management.commands.load_datagetter_data import (
     Command as LoadDatagetterDataCommand,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class Command(LoadDatagetterDataCommand):
@@ -53,6 +57,11 @@ class Command(LoadDatagetterDataCommand):
                             additional_data=additional_data,
                             getter_run=getter_run,
                         )
+                    )
+                else:
+                    logger.warning(
+                        "Found unacceptable data in grant '%s'",
+                        json.dumps(grant.get("id")),
                     )
 
             db.Grant.objects.bulk_create(grant_bulk_insert)

--- a/datastore/db/management/commands/load_data_package.py
+++ b/datastore/db/management/commands/load_data_package.py
@@ -1,11 +1,11 @@
 import copy
-import logging
 import json
+import logging
 
 import db.models as db
-
 from db.management.commands.load_datagetter_data import (
     Command as LoadDatagetterDataCommand,
+    check_grant_data_tools_compatible,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ class Command(LoadDatagetterDataCommand):
                 additional_data = copy.deepcopy(grant["additional_data"])
                 del grant["additional_data"]
 
-                if db.Grant.is_grant_data_acceptable(grant):
+                if check_grant_data_tools_compatible(grant):
                     grant_bulk_insert.append(
                         db.Grant.from_data(
                             source_file=source_file,
@@ -61,6 +61,7 @@ class Command(LoadDatagetterDataCommand):
                 else:
                     logger.warning(
                         "Found unacceptable data in grant '%s'",
+                        # json.dumps() the grant id to escape any unexpected characters
                         json.dumps(grant.get("id")),
                     )
 

--- a/datastore/db/management/commands/load_data_package.py
+++ b/datastore/db/management/commands/load_data_package.py
@@ -44,15 +44,16 @@ class Command(LoadDatagetterDataCommand):
                 additional_data = copy.deepcopy(grant["additional_data"])
                 del grant["additional_data"]
 
-                grant_bulk_insert.append(
-                    db.Grant.from_data(
-                        source_file=source_file,
-                        publisher=publisher,
-                        data=grant,
-                        additional_data=additional_data,
-                        getter_run=getter_run,
+                if db.Grant.is_grant_data_acceptable(grant):
+                    grant_bulk_insert.append(
+                        db.Grant.from_data(
+                            source_file=source_file,
+                            publisher=publisher,
+                            data=grant,
+                            additional_data=additional_data,
+                            getter_run=getter_run,
+                        )
                     )
-                )
 
             db.Grant.objects.bulk_create(grant_bulk_insert)
             grants_added = grants_added + len(grant_data["grants"])

--- a/datastore/db/management/commands/load_datagetter_data.py
+++ b/datastore/db/management/commands/load_datagetter_data.py
@@ -101,15 +101,16 @@ class Command(BaseCommand):
                         )
                         additional_data = None
 
-                    grant_bulk_insert.append(
-                        db.Grant.from_data(
-                            source_file=source_file,
-                            publisher=publisher,
-                            data=grant,
-                            additional_data=additional_data,
-                            getter_run=getter_run,
+                    if db.Grant.is_grant_data_acceptable(grant):
+                        grant_bulk_insert.append(
+                            db.Grant.from_data(
+                                source_file=source_file,
+                                publisher=publisher,
+                                data=grant,
+                                additional_data=additional_data,
+                                getter_run=getter_run,
+                            )
                         )
-                    )
 
                 db.Grant.objects.bulk_create(grant_bulk_insert)
                 grants_added = grants_added + len(grant_data["grants"])

--- a/datastore/db/management/commands/load_datagetter_data.py
+++ b/datastore/db/management/commands/load_datagetter_data.py
@@ -1,13 +1,17 @@
 import json
+import logging
 import os
-from django.db import transaction
+
+from django.core.cache import cache
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
-from django.core.cache import cache
+from django.db import transaction
 
 import db.models as db
 from additional_data.generator import AdditionalDataGenerator
 from db.management.spinner import Spinner
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -110,6 +114,11 @@ class Command(BaseCommand):
                                 additional_data=additional_data,
                                 getter_run=getter_run,
                             )
+                        )
+                    else:
+                        logger.warning(
+                            "Found unacceptable data in grant '%s'",
+                            json.dumps(grant.get("id")),
                         )
 
                 db.Grant.objects.bulk_create(grant_bulk_insert)

--- a/datastore/db/management/commands/load_datagetter_data.py
+++ b/datastore/db/management/commands/load_datagetter_data.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from typing import Dict, Any
 
 from django.core.cache import cache
 from django.core.management import call_command
@@ -12,6 +13,40 @@ from additional_data.generator import AdditionalDataGenerator
 from db.management.spinner import Spinner
 
 logger = logging.getLogger(__name__)
+
+
+def check_grant_data_tools_compatible(grant: Dict[str, Any]) -> bool:
+    """
+    Some Grants contain data that is valid according to the current standard, but not acceptable to tooling
+    e.g. will cause errors when trying to process or render the data.
+    This method checks for such data, with the goal of excluding unacceptable Grants from our dataset.
+
+    Checks made are:
+    - Does the Grant ID contain newline characters
+    - Does any Org IDs contain newline characters
+    """
+    # Does Grant ID contain newlines?
+    grant_id = grant["id"]
+
+    if "\n" in grant_id:
+        return False
+
+    # Does any Org ID contain newlines?
+    # Note we don't check Publisher Org ID because that's not part of the original grant data
+    recipient_org_ids = [
+        ro["id"] for ro in grant["recipientOrganization"] if "id" in ro
+    ]
+    funding_org_ids = [fo["id"] for fo in grant["fundingOrganization"] if "id" in fo]
+
+    for org_id in recipient_org_ids:
+        if "\n" in org_id:
+            return False
+
+    for org_id in funding_org_ids:
+        if "\n" in org_id:
+            return False
+
+    return True
 
 
 class Command(BaseCommand):
@@ -105,7 +140,7 @@ class Command(BaseCommand):
                         )
                         additional_data = None
 
-                    if db.Grant.is_grant_data_acceptable(grant):
+                    if check_grant_data_tools_compatible(grant):
                         grant_bulk_insert.append(
                             db.Grant.from_data(
                                 source_file=source_file,
@@ -118,6 +153,7 @@ class Command(BaseCommand):
                     else:
                         logger.warning(
                             "Found unacceptable data in grant '%s'",
+                            # json.dumps() the grant id to escape any unexpected characters
                             json.dumps(grant.get("id")),
                         )
 

--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -418,6 +418,42 @@ class Grant(models.Model):
             GinIndex(fields=["source_file", "funding_org_ids"]),
         ]
 
+    @classmethod
+    def is_grant_data_acceptable(cls, grant: Dict[str, Any]) -> bool:
+        """
+        Some Grants contain data that is valid according to the current standard, but not acceptable to tooling
+        e.g. will cause errors when trying to process or render the data.
+        This method checks for such data, with the goal of excluding unacceptable Grants from our dataset.
+
+        Checks made are:
+        - Does the Grant ID contain newline characters
+        - Does any Org IDs contain newline characters
+        """
+        # Does Grant ID contain newlines?
+        grant_id = grant["id"]
+
+        if "\n" in grant_id:
+            return False
+
+        # Does any Org ID contain newlines?
+        # Note we don't check Publisher Org ID because that's not part of the original grant data
+        recipient_org_ids = [
+            ro["id"] for ro in grant["recipientOrganization"] if "id" in ro
+        ]
+        funding_org_ids = [
+            fo["id"] for fo in grant["fundingOrganization"] if "id" in fo
+        ]
+
+        for org_id in recipient_org_ids:
+            if "\n" in org_id:
+                return False
+
+        for org_id in funding_org_ids:
+            if "\n" in org_id:
+                return False
+
+        return True
+
     @staticmethod
     def from_data(
         data: Dict[str, Any],

--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -1,12 +1,12 @@
+import datetime
 from typing import Dict, Any
-from django.db.models import JSONField, Index
-from django.db import connection, models
-from django.db.utils import DataError
+
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex, BTreeIndex
+from django.db import connection, models
+from django.db.models import JSONField, Index
+from django.db.utils import DataError
 from django.utils import timezone
-
-import datetime
 
 
 class Latest(models.Model):
@@ -417,42 +417,6 @@ class Grant(models.Model):
             GinIndex(fields=["funding_org_ids"]),
             GinIndex(fields=["source_file", "funding_org_ids"]),
         ]
-
-    @classmethod
-    def is_grant_data_acceptable(cls, grant: Dict[str, Any]) -> bool:
-        """
-        Some Grants contain data that is valid according to the current standard, but not acceptable to tooling
-        e.g. will cause errors when trying to process or render the data.
-        This method checks for such data, with the goal of excluding unacceptable Grants from our dataset.
-
-        Checks made are:
-        - Does the Grant ID contain newline characters
-        - Does any Org IDs contain newline characters
-        """
-        # Does Grant ID contain newlines?
-        grant_id = grant["id"]
-
-        if "\n" in grant_id:
-            return False
-
-        # Does any Org ID contain newlines?
-        # Note we don't check Publisher Org ID because that's not part of the original grant data
-        recipient_org_ids = [
-            ro["id"] for ro in grant["recipientOrganization"] if "id" in ro
-        ]
-        funding_org_ids = [
-            fo["id"] for fo in grant["fundingOrganization"] if "id" in fo
-        ]
-
-        for org_id in recipient_org_ids:
-            if "\n" in org_id:
-                return False
-
-        for org_id in funding_org_ids:
-            if "\n" in org_id:
-                return False
-
-        return True
 
     @staticmethod
     def from_data(

--- a/datastore/tests/test_commands.py
+++ b/datastore/tests/test_commands.py
@@ -1,7 +1,7 @@
+import json
+import os
 from io import StringIO
 from tempfile import TemporaryDirectory
-import os
-import json
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -38,6 +38,48 @@ class CustomMgmtCommandsTest(TransactionTestCase):
             self.assertEqual(
                 len(err_out.getvalue()), 0, "Errors output by load command"
             )
+
+    def test_dont_load_unacceptable_data_from_package(self):
+        err_out = StringIO()
+        with TemporaryDirectory() as tmpdir:
+            call_command("create_data_package", dir=tmpdir, stderr=err_out)
+            self.assertEqual(
+                len(err_out.getvalue()), 0, "Errors output by create command"
+            )
+
+            num_grants = db.Latest.grants().count()
+
+            # Open the data package, replace some data with unacceptable data, then check it doesn't load
+            with open(os.path.join(tmpdir, "data_all.json"), "r") as da_fp:
+                data_all = json.load(da_fp)
+
+            data_0_json_path = os.path.join(
+                tmpdir,
+                "json_all",
+                os.path.basename(data_all[0]["datagetter_metadata"]["json"]),
+            )
+            with open(data_0_json_path, "r") as d0j_fp:
+                first_data_json = json.load(d0j_fp)
+
+            first_data_json["grants"][0]["id"] += "\n"
+            first_data_json["grants"][1]["recipientOrganization"][0]["id"] += "\n"
+            first_data_json["grants"][2]["fundingOrganization"][0]["id"] += "\n"
+
+            with open(data_0_json_path, "w") as d0j_fp:
+                json.dump(first_data_json, d0j_fp)
+
+            call_command("load_data_package", tmpdir, stderr=err_out)
+
+            # The grants we removed should not be included, and there should be no unacceptable data after loading
+            self.assertEqual(db.Latest.grants().count(), num_grants - 3)
+            for grant in db.Latest.grants().all():
+                self.assertNotIn("\n", grant.grant_id)
+
+                for ro in grant.recipient_org_ids:
+                    self.assertNotIn("\n", ro)
+
+                for fo in grant.funding_org_ids:
+                    self.assertNotIn("\n", fo)
 
     def test_delete_datagetter_data(self):
         """


### PR DESCRIPTION
This PR adds to check when loading grants into the datastore to exclude grants that contain data unacceptable to the tooling.