### PR TITLE
urls: pass if django debug tool bar is not installed

### DIFF
--- a/datastore/urls.py
+++ b/datastore/urls.py
@@ -31,5 +31,8 @@ urlpatterns = [
     path("admin/", admin.site.urls, name="admin"),
 ]
 
-if settings.DEBUG:
-    urlpatterns += [path("__debug__/", include("debug_toolbar.urls"))]
+try:
+    if settings.DEBUG:
+        urlpatterns += [path("__debug__/", include("debug_toolbar.urls"))]
+except ModuleNotFoundError:
+    pass


### PR DESCRIPTION
Occasionally it is useful to switch debug on having not installed dev requirements and as this is optional we don't want to cause an exception in a core part of the application.