### PR TITLE
requirements: Upgrade to Django 4

### DIFF
--- a/datastore/settings/settings.py
+++ b/datastore/settings/settings.py
@@ -172,6 +172,10 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
+# Note that as of Django 4.0, USE_L10N = True is made default, and the setting is removed in 5.0
+# See: https://docs.djangoproject.com/en/5.1/releases/4.0/#localization
+#      https://docs.djangoproject.com/en/5.1/releases/5.0/#features-removed-in-5-0
+# Remove this when upgrading to Django 5.
 USE_L10N = True
 
 USE_TZ = True

--- a/datastore/tests/test_browser.py
+++ b/datastore/tests/test_browser.py
@@ -1,7 +1,7 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium import webdriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
 
 import chromedriver_autoinstaller
 
@@ -12,18 +12,18 @@ class BrowserTests(StaticLiveServerTestCase):
     """Browser test using latest Chrome/Chromium stable"""
 
     def setUp(self, *args, **kwargs):
-        capabilities = DesiredCapabilities.CHROME
-        capabilities["loggingPrefs"] = {"browser": "ALL"}
-
         chrome_options = Options()
         chrome_options.add_argument("--headless")
+        chrome_options.set_capability("goog:loggingPrefs", {"browser": "ALL"})
         # uncomment this if "DevToolsActivePort" error
         # chrome_options.add_argument("--remote-debugging-port=9222")
 
+        chrome_service = Service(service_args=["--verbose", "--log-path=selenium.log"])
+
         self.driver = webdriver.Chrome(
-            service_args=["--verbose", "--log-path=selenium.log"],
-            desired_capabilities=capabilities,
-            chrome_options=chrome_options,
+            options=chrome_options,
+            service=chrome_service,
+            #    desired_capabilities=capabilities,
         )
         self.driver.set_page_load_timeout(15)
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,45 @@
--e git+https://github.com/ThreeSixtyGiving/datagetter.git@9c1c431fd0d0b01f0181008fb39bfefde200f534#egg=datagetter
+# Note: this project uses Python 3.8
+
+-e git+https://github.com/ThreeSixtyGiving/datagetter.git@b7462fb250ee60466bb9b8e1ce89c5bdb4682f47#egg=datagetter
 -e git+https://github.com/ThreeSixtyGiving/dataquality.git@e8676bea246ca850b449ff053948059cc611e17f#egg=lib360dataquality
-Django<4.0
-djangorestframework==3.11.2
-django-filter
+
+Django>=4.2,<5.0
+# Use Django 4.2
+# Stable until April 2026 https://endoflife.date/django
+
+djangorestframework>=3.15.2,<3.16
+# DRF claim patch releases are API compatible
+# See: https://www.django-rest-framework.org/community/release-notes/#versioning
+
+django-filter>=22.1,<26
+# django-filter uses "CalVer" releases, says they give two years notice of breaking changes
+# https://github.com/carltongibson/django-filter/blob/main/CHANGES.rst#version-211-2021-9-24
+
 django-prettyjson==0.4.1
-psycopg2==2.8
-prometheus_client==0.7
-django-environ
+# django-prettyjson is very old
+# how does it still work
+
+psycopg2>=2.8,<2.10
+# psycopg2 is in maintenance mode since the release of psycopg3
+# so don't expect any new breaking releases
+
+prometheus_client>=0.7,<0.8
+# prometheus_client seems to use ZeroVer, so "minor" updates can be breaking
+# (inferred from looking at the changelog)
+# Changelog: https://github.com/prometheus/client_python/releases
+# Latest is 0.21 - TODO: Check if newer releases still work?
+
+django-environ>=0.9.0,<0.10
+# django-environ uses ZeroVer, so "minor" updates can be breaking
+# Latest is v0.11 - TODO: Check if newer releases still work?
+# Changelog: https://django-environ.readthedocs.io/en/latest/changelog.html
+
 drf-spectacular>=0.27,<0.28
+# drf-spectacular uses ZeroVer, so "minor" updates can be breaking
+# See: https://drf-spectacular.readthedocs.io/en/latest/readme.html#release-management
+# Changelog: https://drf-spectacular.readthedocs.io/en/latest/changelog.html
+
 djangorestframework-dataclasses>=1.3.1,<2
+# drf-dataclasses uses Semantic Versioning according to https://semver.org/
+# See: https://github.com/oxan/djangorestframework-dataclasses/blob/master/README.rst#installation
+# Changelog: https://github.com/oxan/djangorestframework-dataclasses/blob/master/CHANGELOG.rst

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # Note: this project uses Python 3.8
 
--e git+https://github.com/ThreeSixtyGiving/datagetter.git@b7462fb250ee60466bb9b8e1ce89c5bdb4682f47#egg=datagetter
+-e git+https://github.com/ThreeSixtyGiving/datagetter.git@a532cfa17fe72212f1c2e4b268891c1e70eaabe6#egg=datagetter
 -e git+https://github.com/ThreeSixtyGiving/dataquality.git@e8676bea246ca850b449ff053948059cc611e17f#egg=lib360dataquality
 
 Django>=4.2,<5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
--e git+https://github.com/ThreeSixtyGiving/datagetter.git@b7462fb250ee60466bb9b8e1ce89c5bdb4682f47#egg=datagetter
+-e git+https://github.com/ThreeSixtyGiving/datagetter.git@a532cfa17fe72212f1c2e4b268891c1e70eaabe6#egg=datagetter
     # via -r requirements.in
 -e git+https://github.com/ThreeSixtyGiving/dataquality.git@e8676bea246ca850b449ff053948059cc611e17f#egg=lib360dataquality
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,49 +4,47 @@
 #
 #    pip-compile requirements.in
 #
--e git+https://github.com/ThreeSixtyGiving/datagetter.git@9c1c431fd0d0b01f0181008fb39bfefde200f534#egg=datagetter
+-e git+https://github.com/ThreeSixtyGiving/datagetter.git@b7462fb250ee60466bb9b8e1ce89c5bdb4682f47#egg=datagetter
     # via -r requirements.in
 -e git+https://github.com/ThreeSixtyGiving/dataquality.git@e8676bea246ca850b449ff053948059cc611e17f#egg=lib360dataquality
     # via -r requirements.in
-apsw==3.45.3.0
+apsw==3.46.1.0
     # via datagetter
-asgiref==3.5.2
+asgiref==3.8.1
     # via django
 attrs==21.2.0
     # via
     #   datagetter
     #   jsonschema
-backports-datetime-fromisoformat==1.0.0
+backports-datetime-fromisoformat==2.0.2
     # via
     #   datagetter
     #   flattentool
-btrees==4.9.2
+backports-zoneinfo==0.2.1
+    # via
+    #   django
+    #   djangorestframework
+btrees==6.1
     # via
     #   datagetter
     #   zodb
-cached-property==1.5.2
-    # via libcove
-certifi==2023.7.22
+certifi==2024.8.30
     # via
     #   datagetter
     #   requests
-cffi==1.15.0
+cffi==1.17.1
     # via
     #   datagetter
     #   persistent
-charset-normalizer==2.0.7
+charset-normalizer==3.4.0
     # via
     #   datagetter
     #   requests
-contextlib2==21.6.0
-    # via
-    #   datagetter
-    #   schema
 defusedxml==0.7.1
     # via
     #   datagetter
     #   odfpy
-django==3.2.16
+django==4.2.16
     # via
     #   -r requirements.in
     #   django-filter
@@ -56,43 +54,39 @@ django==3.2.16
     #   drf-spectacular
 django-environ==0.9.0
     # via -r requirements.in
-django-filter==22.1
+django-filter==24.3
     # via -r requirements.in
 django-prettyjson==0.4.1
     # via -r requirements.in
-djangorestframework==3.11.2
+djangorestframework==3.15.2
     # via
     #   -r requirements.in
     #   djangorestframework-dataclasses
     #   drf-spectacular
 djangorestframework-dataclasses==1.3.1
     # via -r requirements.in
-drf-spectacular==0.27.0
+drf-spectacular==0.27.2
     # via -r requirements.in
-et-xmlfile==1.1.0
+et-xmlfile==2.0.0
     # via
     #   datagetter
     #   openpyxl
-flattentool==0.17.1
+flattentool==0.26.0
     # via
     #   datagetter
     #   libcove
-idna==3.3
+idna==3.10
     # via
     #   datagetter
     #   requests
-ijson==3.1.4
+ijson==3.3.0
     # via
     #   datagetter
     #   flattentool
     #   lib360dataquality
 inflection==0.5.1
     # via drf-spectacular
-jdcal==1.4.1
-    # via
-    #   datagetter
-    #   openpyxl
-jsonref==0.2
+jsonref==1.1.0
     # via
     #   datagetter
     #   flattentool
@@ -103,9 +97,9 @@ jsonschema==3.2.0
     #   drf-spectacular
     #   lib360dataquality
     #   libcove
-libcove==0.29.0
+libcove==0.31.0
     # via lib360dataquality
-lxml==4.6.4
+lxml==5.3.0
     # via
     #   datagetter
     #   flattentool
@@ -113,24 +107,24 @@ odfpy==1.4.1
     # via
     #   datagetter
     #   flattentool
-openpyxl==2.6.4
+openpyxl==3.0.10
     # via
     #   datagetter
     #   flattentool
-persistent==4.7.0
+persistent==6.1
     # via
     #   btrees
     #   datagetter
     #   zodb
-prometheus-client==0.7
+prometheus-client==0.7.1
     # via -r requirements.in
-psycopg2==2.8
+psycopg2==2.9.10
     # via -r requirements.in
-pycparser==2.21
+pycparser==2.22
     # via
     #   cffi
     #   datagetter
-pyrsistent==0.18.0
+pyrsistent==0.20.0
     # via
     #   datagetter
     #   jsonschema
@@ -138,18 +132,17 @@ pysocks==1.7.1
     # via
     #   datagetter
     #   requests
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via lib360dataquality
-pytz==2021.3
+pytz==2024.2
     # via
     #   datagetter
-    #   django
     #   flattentool
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via drf-spectacular
 rangedict==0.1.7
     # via lib360dataquality
-requests[socks]==2.26.0
+requests[socks]==2.32.3
     # via
     #   datagetter
     #   libcove
@@ -159,7 +152,7 @@ rfc3987==1.3.8
     # via
     #   datagetter
     #   libcove
-schema==0.7.4
+schema==0.7.7
     # via
     #   datagetter
     #   flattentool
@@ -169,30 +162,32 @@ six==1.16.0
     #   django-prettyjson
     #   jsonschema
     #   python-dateutil
-    #   zodb
-sqlparse==0.4.3
+    #   rfc3339-validator
+sqlparse==0.5.2
     # via django
 standardjson==0.3.1
     # via django-prettyjson
 strict-rfc3339==0.7
     # via datagetter
-transaction==3.0.1
+transaction==5.0
     # via
     #   datagetter
     #   zodb
-typing-extensions==4.9.0
-    # via drf-spectacular
+typing-extensions==4.12.2
+    # via
+    #   asgiref
+    #   drf-spectacular
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==1.26.7
+urllib3==2.2.3
     # via
     #   datagetter
     #   requests
-xmltodict==0.12.0
+xmltodict==0.14.2
     # via
     #   datagetter
     #   flattentool
-zc-lockfile==2.0
+zc-lockfile==3.0.post1
     # via
     #   datagetter
     #   zodb
@@ -200,20 +195,24 @@ zc-zlibstorage==1.2.0
     # via
     #   datagetter
     #   flattentool
-zconfig==3.6.0
+zconfig==4.1
     # via
     #   datagetter
     #   zodb
-zodb==5.6.0
+zodb==6.0
     # via
     #   datagetter
     #   flattentool
     #   zc-zlibstorage
-zodbpickle==2.2.0
+zodbpickle==4.1.1
     # via
     #   datagetter
     #   zodb
-zope-interface==5.4.0
+zope-deferredimport==5.0
+    # via
+    #   datagetter
+    #   persistent
+zope-interface==7.1.1
     # via
     #   btrees
     #   datagetter
@@ -221,6 +220,11 @@ zope-interface==5.4.0
     #   transaction
     #   zc-zlibstorage
     #   zodb
+    #   zope-proxy
+zope-proxy==6.1
+    # via
+    #   datagetter
+    #   zope-deferredimport
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -1,9 +1,29 @@
 -r requirements.in
-selenium
-flake8
-black
-requests_mock
-coveralls
+
+selenium>=4.7.2,<4.27
+# Changelog: https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES
+
+flake8>=6.0,<6.1
+
+black>=22.12.0,<23
+# black changes the format slightly in newer versions
+# Stability Policy: https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy
+
+requests-mock>=1.10.0,<2
+# requests-mock stopped updating the changelog after 1.10?
+# Changelog: https://requests-mock.readthedocs.io/en/latest/release-notes.html
+
+coveralls==3.3.1,<4
+# coveralls package seems to use semantic versioning
+# Changelog: https://github.com/TheKevJames/coveralls-python/blob/master/CHANGELOG.md
+
 chromedriver-autoinstaller
-django-cors-headers
-django-debug-toolbar>=4.3,<4.4 # When upgrading DDT, check that newer versions still support Django 3.2.
+# We always want the latest version, to keep up to date with new Chrome versions
+
+django-cors-headers<4.5
+# django-cors-headers support for Python 3.8 is dropped in 4.5.0
+# See: https://github.com/adamchainz/django-cors-headers/blob/main/CHANGELOG.rst#450-2024-10-12
+
+django-debug-toolbar>=4.3.0,<5
+# django-debug-toolbar does sometimes break things in "minor" releases
+# Changelog: https://django-debug-toolbar.readthedocs.io/en/latest/changes.html

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements_dev.in
 #
--e git+https://github.com/ThreeSixtyGiving/datagetter.git@b7462fb250ee60466bb9b8e1ce89c5bdb4682f47#egg=datagetter
+-e git+https://github.com/ThreeSixtyGiving/datagetter.git@a532cfa17fe72212f1c2e4b268891c1e70eaabe6#egg=datagetter
     # via -r /home/rikki/Projects/datastore/requirements.in
 -e git+https://github.com/ThreeSixtyGiving/dataquality.git@e8676bea246ca850b449ff053948059cc611e17f#egg=lib360dataquality
     # via -r /home/rikki/Projects/datastore/requirements.in

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,57 +4,53 @@
 #
 #    pip-compile requirements_dev.in
 #
--e git+https://github.com/ThreeSixtyGiving/datagetter.git@9c1c431fd0d0b01f0181008fb39bfefde200f534#egg=datagetter
-    # via -r requirements.in
+-e git+https://github.com/ThreeSixtyGiving/datagetter.git@b7462fb250ee60466bb9b8e1ce89c5bdb4682f47#egg=datagetter
+    # via -r /home/rikki/Projects/datastore/requirements.in
 -e git+https://github.com/ThreeSixtyGiving/dataquality.git@e8676bea246ca850b449ff053948059cc611e17f#egg=lib360dataquality
-    # via -r requirements.in
-apsw==3.45.3.0
+    # via -r /home/rikki/Projects/datastore/requirements.in
+apsw==3.46.1.0
     # via datagetter
-asgiref==3.5.2
-    # via django
-async-generator==1.10
+asgiref==3.8.1
     # via
-    #   trio
-    #   trio-websocket
+    #   django
+    #   django-cors-headers
 attrs==21.2.0
     # via
     #   datagetter
     #   jsonschema
     #   outcome
     #   trio
-backports-datetime-fromisoformat==1.0.0
+backports-datetime-fromisoformat==2.0.2
     # via
     #   datagetter
     #   flattentool
+backports-zoneinfo==0.2.1
+    # via
+    #   django
+    #   djangorestframework
 black==22.12.0
     # via -r requirements_dev.in
-btrees==4.9.2
+btrees==6.1
     # via
     #   datagetter
     #   zodb
-cached-property==1.5.2
-    # via libcove
-certifi==2023.7.22
+certifi==2024.8.30
     # via
     #   datagetter
     #   requests
     #   selenium
-cffi==1.15.0
+cffi==1.17.1
     # via
     #   datagetter
     #   persistent
-charset-normalizer==2.0.7
+charset-normalizer==3.4.0
     # via
     #   datagetter
     #   requests
-chromedriver-autoinstaller==0.4.0
+chromedriver-autoinstaller==0.6.4
     # via -r requirements_dev.in
-click==8.1.3
+click==8.1.7
     # via black
-contextlib2==21.6.0
-    # via
-    #   datagetter
-    #   schema
 coverage==6.5.0
     # via coveralls
 coveralls==3.3.1
@@ -63,9 +59,9 @@ defusedxml==0.7.1
     # via
     #   datagetter
     #   odfpy
-django==3.2.16
+django==4.2.16
     # via
-    #   -r requirements.in
+    #   -r /home/rikki/Projects/datastore/requirements.in
     #   django-cors-headers
     #   django-debug-toolbar
     #   django-filter
@@ -73,58 +69,56 @@ django==3.2.16
     #   djangorestframework
     #   djangorestframework-dataclasses
     #   drf-spectacular
-django-cors-headers==3.13.0
+django-cors-headers==4.4.0
     # via -r requirements_dev.in
-django-debug-toolbar==4.3.0
+django-debug-toolbar==4.4.6
     # via -r requirements_dev.in
 django-environ==0.9.0
-    # via -r requirements.in
-django-filter==22.1
-    # via -r requirements.in
+    # via -r /home/rikki/Projects/datastore/requirements.in
+django-filter==24.3
+    # via -r /home/rikki/Projects/datastore/requirements.in
 django-prettyjson==0.4.1
-    # via -r requirements.in
-djangorestframework==3.11.2
+    # via -r /home/rikki/Projects/datastore/requirements.in
+djangorestframework==3.15.2
     # via
-    #   -r requirements.in
+    #   -r /home/rikki/Projects/datastore/requirements.in
     #   djangorestframework-dataclasses
     #   drf-spectacular
 djangorestframework-dataclasses==1.3.1
-    # via -r requirements.in
+    # via -r /home/rikki/Projects/datastore/requirements.in
 docopt==0.6.2
     # via coveralls
-drf-spectacular==0.27.0
-    # via -r requirements.in
-et-xmlfile==1.1.0
+drf-spectacular==0.27.2
+    # via -r /home/rikki/Projects/datastore/requirements.in
+et-xmlfile==2.0.0
     # via
     #   datagetter
     #   openpyxl
-exceptiongroup==1.0.4
-    # via trio
+exceptiongroup==1.2.2
+    # via
+    #   trio
+    #   trio-websocket
 flake8==6.0.0
     # via -r requirements_dev.in
-flattentool==0.17.1
+flattentool==0.26.0
     # via
     #   datagetter
     #   libcove
 h11==0.14.0
     # via wsproto
-idna==3.3
+idna==3.10
     # via
     #   datagetter
     #   requests
     #   trio
-ijson==3.1.4
+ijson==3.3.0
     # via
     #   datagetter
     #   flattentool
     #   lib360dataquality
 inflection==0.5.1
     # via drf-spectacular
-jdcal==1.4.1
-    # via
-    #   datagetter
-    #   openpyxl
-jsonref==0.2
+jsonref==1.1.0
     # via
     #   datagetter
     #   flattentool
@@ -135,48 +129,50 @@ jsonschema==3.2.0
     #   drf-spectacular
     #   lib360dataquality
     #   libcove
-libcove==0.29.0
+libcove==0.31.0
     # via lib360dataquality
-lxml==4.6.4
+lxml==5.3.0
     # via
     #   datagetter
     #   flattentool
 mccabe==0.7.0
     # via flake8
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
 odfpy==1.4.1
     # via
     #   datagetter
     #   flattentool
-openpyxl==2.6.4
+openpyxl==3.0.10
     # via
     #   datagetter
     #   flattentool
-outcome==1.2.0
+outcome==1.3.0.post0
     # via trio
-pathspec==0.10.3
+packaging==24.2
+    # via chromedriver-autoinstaller
+pathspec==0.12.1
     # via black
-persistent==4.7.0
+persistent==6.1
     # via
     #   btrees
     #   datagetter
     #   zodb
-platformdirs==2.6.0
+platformdirs==4.3.6
     # via black
-prometheus-client==0.7
-    # via -r requirements.in
-psycopg2==2.8
-    # via -r requirements.in
+prometheus-client==0.7.1
+    # via -r /home/rikki/Projects/datastore/requirements.in
+psycopg2==2.9.10
+    # via -r /home/rikki/Projects/datastore/requirements.in
 pycodestyle==2.10.0
     # via flake8
-pycparser==2.21
+pycparser==2.22
     # via
     #   cffi
     #   datagetter
 pyflakes==3.0.1
     # via flake8
-pyrsistent==0.18.0
+pyrsistent==0.20.0
     # via
     #   datagetter
     #   jsonschema
@@ -185,24 +181,23 @@ pysocks==1.7.1
     #   datagetter
     #   requests
     #   urllib3
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via lib360dataquality
-pytz==2021.3
+pytz==2024.2
     # via
     #   datagetter
-    #   django
     #   flattentool
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via drf-spectacular
 rangedict==0.1.7
     # via lib360dataquality
-requests[socks]==2.26.0
+requests[socks]==2.32.3
     # via
     #   coveralls
     #   datagetter
     #   libcove
     #   requests-mock
-requests-mock==1.10.0
+requests-mock==1.12.1
     # via -r requirements_dev.in
 rfc3339-validator==0.1.4
     # via libcove
@@ -210,11 +205,11 @@ rfc3987==1.3.8
     # via
     #   datagetter
     #   libcove
-schema==0.7.4
+schema==0.7.7
     # via
     #   datagetter
     #   flattentool
-selenium==4.7.2
+selenium==4.26.1
     # via -r requirements_dev.in
 six==1.16.0
     # via
@@ -222,14 +217,12 @@ six==1.16.0
     #   django-prettyjson
     #   jsonschema
     #   python-dateutil
-    #   requests-mock
     #   rfc3339-validator
-    #   zodb
-sniffio==1.3.0
+sniffio==1.3.1
     # via trio
 sortedcontainers==2.4.0
     # via trio
-sqlparse==0.4.3
+sqlparse==0.5.2
     # via
     #   django
     #   django-debug-toolbar
@@ -237,36 +230,40 @@ standardjson==0.3.1
     # via django-prettyjson
 strict-rfc3339==0.7
     # via datagetter
-tomli==2.0.1
+tomli==2.1.0
     # via black
-transaction==3.0.1
+transaction==5.0
     # via
     #   datagetter
     #   zodb
-trio==0.22.0
+trio==0.24.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.11.1
     # via selenium
-typing-extensions==4.4.0
+typing-extensions==4.12.2
     # via
+    #   asgiref
     #   black
     #   drf-spectacular
+    #   selenium
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3[socks]==1.26.7
+urllib3[socks]==2.2.3
     # via
     #   datagetter
     #   requests
     #   selenium
+websocket-client==1.8.0
+    # via selenium
 wsproto==1.2.0
     # via trio-websocket
-xmltodict==0.12.0
+xmltodict==0.14.2
     # via
     #   datagetter
     #   flattentool
-zc-lockfile==2.0
+zc-lockfile==3.0.post1
     # via
     #   datagetter
     #   zodb
@@ -274,20 +271,24 @@ zc-zlibstorage==1.2.0
     # via
     #   datagetter
     #   flattentool
-zconfig==3.6.0
+zconfig==4.1
     # via
     #   datagetter
     #   zodb
-zodb==5.6.0
+zodb==6.0
     # via
     #   datagetter
     #   flattentool
     #   zc-zlibstorage
-zodbpickle==2.2.0
+zodbpickle==4.1.1
     # via
     #   datagetter
     #   zodb
-zope-interface==5.4.0
+zope-deferredimport==5.0
+    # via
+    #   datagetter
+    #   persistent
+zope-interface==7.1.1
     # via
     #   btrees
     #   datagetter
@@ -295,6 +296,11 @@ zope-interface==5.4.0
     #   transaction
     #   zc-zlibstorage
     #   zodb
+    #   zope-proxy
+zope-proxy==6.1
+    # via
+    #   datagetter
+    #   zope-deferredimport
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
This PR primarily upgrades the datastore to Django 4, due to the now-passed end of support for Django 3.

Thankfully no code changes were required for the Django upgrade, only the `USE_L10N` setting is deprecated.

The project used a very old version of Selenium to run browser tests, which had some sub-requirement versions incompatible with Django 4, so I had to upgrade Selenium with a minor change in how the Chrome webdriver is set up.

Due to the datagetter's `requirements.txt` being pulled in, this PR depends on https://github.com/ThreeSixtyGiving/datagetter/pull/59 

This PR also adds notes to each requirement listed in `requirements.in` / `requirements_dev.in` summarising each projects' version compatibility policy, and updates the version specifiers based on each policy.

- [x] TODO: When datagetter PR is merged, update the hash ref in `requirements.in` in this PR