### PR TITLE
rewrite_quality_data: Always use latest publisher object

### DIFF
--- a/datastore/data_quality/management/commands/rewrite_quality_data.py
+++ b/datastore/data_quality/management/commands/rewrite_quality_data.py
@@ -98,7 +98,16 @@ class Command(BaseCommand):
             )
 
         def process_publishers(source_file):
-            publisher = source_file.get_publisher()
+            """Updates the publisher data with aggregates and quality data relating to their source files"""
+
+            # We want to store the quality and aggregate data against the latest version of the publisher
+            # object rather than the version from the getter_run that this source file came from
+            # This is so that when we serialise the latest publishers we get the latest aggregate and
+            # quality data regardless of when the source file entered the system.
+            publisher = db.Publisher.objects.get(
+                getter_run=db.GetterRun.latest(),
+                prefix=source_file.data["publisher"]["prefix"],
+            )
 
             print(publisher)
 

--- a/datastore/db/models.py
+++ b/datastore/db/models.py
@@ -185,6 +185,7 @@ class SourceFile(models.Model):
         return self.data["distribution"][0]
 
     def get_publisher(self):
+        """returns the Publisher object for this source file"""
         return Publisher.objects.get(
             getter_run=self.getter_run, prefix=self.data["publisher"]["prefix"]
         )


### PR DESCRIPTION
Instead of writing the quality/aggregate data to the publisher object that is associated with the datagetter run from the source file always write it to the latest set of publishers.