### PR TITLE
workflows: Pin to specific ubuntu version and remove actions cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:12
@@ -25,11 +25,6 @@ jobs:
       with:
         python-version: 3.8
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/requirements_dev.txt') }}
-
     # For generating random data
     - run: sudo apt-get install pwgen
 


### PR DESCRIPTION
ubuntu-latest is now changing and actions cache is no longer needed.