### PR TITLE
Source license info in additional_data

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,16 +5,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/requirements_dev.txt') }}
 
     - run: pip install -r requirements.txt
     - run: pip install -r requirements_dev.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
         ports:
           - 5432:5432/tcp
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
         architecture: x64

--- a/datastore/additional_data/generator.py
+++ b/datastore/additional_data/generator.py
@@ -8,6 +8,7 @@ from additional_data.sources.additional_data_recipient_location import (
 from additional_data.sources.codelist_code import CodeListSource
 from additional_data.sources.tsg_recipient_types import TSGRecipientTypesSource
 from additional_data.sources.imd_snapshot import IMDSnapshotSource
+from additional_data.sources.grant_metadata import GrantMetadataSource
 
 
 # This ordering is important for any data dependencies
@@ -21,6 +22,7 @@ DATA_SOURCES = [
     "code_lists",
     "tsg_recipient_type",
     "imd_snapshot",
+    "grant_metadata",
 ]
 
 
@@ -36,17 +38,22 @@ class AdditionalDataGenerator(object):
         self.code_lists = CodeListSource()
         self.tsg_recipient_type = TSGRecipientTypesSource()
         self.imd_snapshot = IMDSnapshotSource()
-        # Initialise Other Sources here
+        self.grant_metadata = GrantMetadataSource()
+        # Initialise other additional data sources here
 
-    def create(self, grant, data_sources=DATA_SOURCES):
+    def create(self, grant, source_file, additional_data_sources=DATA_SOURCES):
         """Takes a grant's data and returns a dict of additional data"""
 
         additional_data = {}
 
-        for source in data_sources:
+        for additional_data_source in additional_data_sources:
             try:
-                getattr(self, source).update_additional_data(grant, additional_data)
+                getattr(self, additional_data_source).update_additional_data(
+                    grant, source_file, additional_data
+                )
             except AttributeError:
-                raise Exception(f"Data source {source} is not a known data source.")
+                raise Exception(
+                    f"Data source {additional_data_source} is not a known additional data source."
+                )
 
         return additional_data

--- a/datastore/additional_data/management/commands/additional_data_tool.py
+++ b/datastore/additional_data/management/commands/additional_data_tool.py
@@ -16,7 +16,27 @@ class Command(BaseCommand):
             help="The JSON file that contains an array of ThreeSixtyGiving grant data",
         )
 
+        parser.add_argument(
+            "--license-name",
+            action="store",
+            dest="license_name",
+            help="The name of the license under which this grant data is published",
+        )
+
+        parser.add_argument(
+            "--license-url",
+            action="store",
+            dest="license",
+            help="The URL of the license under which this grant data is published",
+        )
+
     def handle(self, *args, **options):
+
+        source_file = {}
+        if options["license_name"]:
+            source_file["license_name"] = options["license_name"]
+        if options["license"]:
+            source_file["license"] = options["license"]
 
         with open(options["grants_file"]) as grants_file:
             grants_json = json.load(grants_file)
@@ -24,7 +44,7 @@ class Command(BaseCommand):
             generator = AdditionalDataGenerator()
 
             for grant in grants_json["grants"]:
-                additional_data = generator.create(grant)
+                additional_data = generator.create(grant, source_file)
                 grant["additional_data"] = additional_data
 
             with open(options["grants_file"], "w") as grants_file:

--- a/datastore/additional_data/management/commands/rewrite_additional_data.py
+++ b/datastore/additional_data/management/commands/rewrite_additional_data.py
@@ -44,9 +44,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if "latest" in options["getter_run"]:
-            grants = Latest.objects.get(series=Latest.CURRENT).grant_set.all()
+            grants = (
+                Latest.objects.get(series=Latest.CURRENT)
+                .grant_set.select_related("source_file")
+                .all()
+            )
         else:
-            grants = Grant.objects.filter(getter_run=options["getter_run"])
+            grants = Grant.objects.select_related("source_file").filter(
+                getter_run=options["getter_run"]
+            )
 
         generator = AdditionalDataGenerator()
         data_sources = options["data_sources"]
@@ -64,9 +70,15 @@ class Command(BaseCommand):
 
             for grant in page_grants:
                 if data_sources:
-                    additional_data = generator.create(grant.data, data_sources)
+                    additional_data = generator.create(
+                        grant.data,
+                        grant.source_file.data,
+                        additional_data_sources=data_sources,
+                    )
                 else:
-                    additional_data = generator.create(grant.data)
+                    additional_data = generator.create(
+                        grant.data, grant.source_file.data
+                    )
 
                 grant.additional_data = additional_data
 

--- a/datastore/additional_data/sources/additional_data_recipient_location.py
+++ b/datastore/additional_data/sources/additional_data_recipient_location.py
@@ -16,7 +16,7 @@ class AdditionalDataRecipientLocation(object):
        "recipientLocation", # string of all the above
     """
 
-    def update_additional_data(self, grant, additional_data):
+    def update_additional_data(self, grant, source_file, additional_data):
         # If we have locationLookup from beneficiaryLocation or we don't have any
         # recipientRegionName take whatever data we can from locationLookup instead
         # which is populated in geo_lookup

--- a/datastore/additional_data/sources/codelist_code.py
+++ b/datastore/additional_data/sources/codelist_code.py
@@ -42,9 +42,8 @@ class CodeListSource(object):
                             list_name=list_name,
                         )
 
-    def update_additional_data(self, grant, additional_data):
-        # check All the fields in the grant data that use codelists and make
-        # additional data field versions of them
+    def update_additional_data(self, grant, source_file, additional_data):
+        # check All the fields in the grant data that use codelists and make additional data field versions of them
 
         primaryGrantReason = ""
         secondaryGrantReason = ""

--- a/datastore/additional_data/sources/find_that_charity.py
+++ b/datastore/additional_data/sources/find_that_charity.py
@@ -78,7 +78,7 @@ class FindThatCharitySource(object):
         # This cache object typical size 68,458
         self._cache = {}
 
-    def update_additional_data(self, grant, additional_data):
+    def update_additional_data(self, grant, source_file, additional_data):
         # We can't do anything if this grant doesn't have a recipientOrganization
         if not grant.get("recipientOrganization"):
             return

--- a/datastore/additional_data/sources/geo_lookup.py
+++ b/datastore/additional_data/sources/geo_lookup.py
@@ -114,7 +114,7 @@ class GeoLookupSource(object):
         except GeoLookup.DoesNotExist:
             pass
 
-    def update_additional_data(self, grant, additional_data):
+    def update_additional_data(self, grant, source_file, additional_data):
         """Updates with 'locationLookup' based on available areas."""
         additional_data["locationLookup"] = []
 

--- a/datastore/additional_data/sources/grant_metadata.py
+++ b/datastore/additional_data/sources/grant_metadata.py
@@ -1,0 +1,22 @@
+class GrantMetadataSource(object):
+    """Adds metadata to a grant:
+    * metadata/source_license
+    * metadata/source_license_name
+    """
+
+    ADDITIONAL_DATA_KEY = "metadata"
+
+    def update_additional_data(self, grant, source_file, additional_data):
+
+        additional_data[self.ADDITIONAL_DATA_KEY] = {}
+
+        # Add license information from the source of the data.
+        if source_file.get("license_name"):
+            additional_data[self.ADDITIONAL_DATA_KEY][
+                "source_license_name"
+            ] = source_file.get("license_name")
+
+        if source_file.get("license"):
+            additional_data[self.ADDITIONAL_DATA_KEY][
+                "source_license"
+            ] = source_file.get("license")

--- a/datastore/additional_data/sources/imd_snapshot.py
+++ b/datastore/additional_data/sources/imd_snapshot.py
@@ -45,6 +45,6 @@ class IMDSnapshotSource:
 
         logger.info(f"Loaded {len(created)} Wards from CSV")
 
-    def update_additional_data(self, grant, additional_data):
+    def update_additional_data(self, grant, source_file, additional_data):
         # TODO: Annotate additional_data with IMD & population values
         pass

--- a/datastore/additional_data/sources/nspl.py
+++ b/datastore/additional_data/sources/nspl.py
@@ -189,7 +189,7 @@ class NSPLSource(object):
 
         return location_data
 
-    def update_additional_data(self, grant, additional_data):
+    def update_additional_data(self, grant, source_file, additional_data):
         """
         Updates with 'recipientOrganizationLocation' based on it's postcode.
         It checks first the `recipientOrganization` `postalCode` in the grant.

--- a/datastore/additional_data/sources/tsg_org_types.py
+++ b/datastore/additional_data/sources/tsg_org_types.py
@@ -27,7 +27,7 @@ class TSGOrgTypesSource(object):
             except re.error:
                 continue
 
-    def update_additional_data(self, grant, additional_data):
+    def update_additional_data(self, grant, source_file, additional_data):
         try:
             funding_org_id = grant["fundingOrganization"][0]["id"]
         except (KeyError, TypeError) as e:

--- a/datastore/additional_data/sources/tsg_recipient_types.py
+++ b/datastore/additional_data/sources/tsg_recipient_types.py
@@ -5,7 +5,7 @@ class TSGRecipientTypesSource(object):
 
     ADDITIONAL_DATA_KEY = "TSGRecipientType"
 
-    def update_additional_data(self, grant, additional_data):
+    def update_additional_data(self, grant, source_file, additional_data):
         try:
             grant["recipientOrganization"][0]["id"]
             additional_data[self.ADDITIONAL_DATA_KEY] = "Organisation"

--- a/datastore/db/management/commands/load_datagetter_data.py
+++ b/datastore/db/management/commands/load_datagetter_data.py
@@ -157,7 +157,9 @@ class Command(BaseCommand):
 
                 for grant in grant_data["grants"]:
                     try:
-                        additional_data = grant_additional_data_generator.create(grant)
+                        additional_data = grant_additional_data_generator.create(
+                            grant, source_file.data
+                        )
                     except Exception as e:
                         print(
                             "Generating additional for grant %s failed %s"

--- a/datastore/tests/test_additional_data_codelist_code.py
+++ b/datastore/tests/test_additional_data_codelist_code.py
@@ -18,6 +18,8 @@ class TestCodeLists(TestCase):
             "locationScope": "GLS040",
         }
 
+        source_file = {}
+
         additional_data_in = {}
 
         expected_additional_data_out = {
@@ -32,7 +34,7 @@ class TestCodeLists(TestCase):
             }
         }
 
-        source.update_additional_data(grant, additional_data_in)
+        source.update_additional_data(grant, source_file, additional_data_in)
 
         self.assertEqual(
             additional_data_in,

--- a/datastore/tests/test_additional_data_ftc.py
+++ b/datastore/tests/test_additional_data_ftc.py
@@ -50,7 +50,9 @@ class TestAdditionalData(TestCase):
 
         additional_data = {}
 
-        find_that_charity_source.update_additional_data(grant.data, additional_data)
+        find_that_charity_source.update_additional_data(
+            grant.data, grant.source_file.data, additional_data
+        )
 
         self.assertEqual(
             FindThatCharitySource.ADDITIONAL_DATA_KEY in additional_data,

--- a/datastore/tests/test_additional_data_geolookups.py
+++ b/datastore/tests/test_additional_data_geolookups.py
@@ -113,7 +113,7 @@ class TestAdditionalDataGeoLookup(TestCase):
 
         additional_data = {}
         geo = GeoLookupSource()
-        geo.update_additional_data(grant.data, additional_data)
+        geo.update_additional_data(grant.data, grant.source_file.data, additional_data)
 
         self.assertIn("locationLookup", additional_data)
         self.assertEqual(
@@ -139,7 +139,7 @@ class TestAdditionalDataGeoLookup(TestCase):
         }
 
         geo = GeoLookupSource()
-        geo.update_additional_data(grant.data, additional_data)
+        geo.update_additional_data(grant.data, grant.source_file.data, additional_data)
 
         self.assertIn("locationLookup", additional_data)
         self.assertEqual(
@@ -157,7 +157,7 @@ class TestAdditionalDataGeoLookup(TestCase):
 
         additional_data = {}
         geo = GeoLookupSource()
-        geo.update_additional_data(grant.data, additional_data)
+        geo.update_additional_data(grant.data, grant.source_file.data, additional_data)
 
         self.assertIn("locationLookup", additional_data)
         self.assertEqual(
@@ -180,7 +180,7 @@ class TestAdditionalDataGeoLookup(TestCase):
             "recipientOrganizationLocation": {"lsoa11": self.EXISTING_AREA}
         }
         geo = GeoLookupSource()
-        geo.update_additional_data(grant.data, additional_data)
+        geo.update_additional_data(grant.data, grant.source_file.data, additional_data)
 
         self.assertIn("locationLookup", additional_data)
         self.assertEqual(

--- a/datastore/tests/test_additional_data_license.py
+++ b/datastore/tests/test_additional_data_license.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+
+from additional_data.sources.grant_metadata import GrantMetadataSource
+from db.models import Grant
+
+
+class TestAdditionalDataLicense(TestCase):
+    fixtures = ["test_data.json"]
+
+    def test_publisher_license(self):
+        grant_metadata_source = GrantMetadataSource()
+
+        grant = Grant.objects.first()
+        additional_data = {}
+
+        expected_additional_data = {
+            "metadata": {
+                "source_license_name": "Creative Commons Attribution 4.0",
+                "source_license": "https://creativecommons.org/licenses/by/4.0/",
+            }
+        }
+
+        grant_metadata_source.update_additional_data(
+            grant.data, grant.source_file.data, additional_data
+        )
+
+        self.assertEqual(
+            GrantMetadataSource.ADDITIONAL_DATA_KEY in additional_data,
+            True,
+            "Additional license data was not added.",
+        )
+
+        self.assertEqual(
+            additional_data,
+            expected_additional_data,
+            "The additional license data added is not correct.",
+        )

--- a/datastore/tests/test_additional_data_nspl.py
+++ b/datastore/tests/test_additional_data_nspl.py
@@ -138,7 +138,7 @@ class TestAdditionalDataNSPL(TestCase):
 
         additional_data = {}
         nspl = NSPLSource()
-        nspl.update_additional_data(grant.data, additional_data)
+        nspl.update_additional_data(grant.data, grant.source_file.data, additional_data)
 
         self.assertIn("recipientOrganizationLocation", additional_data)
         self.assertEqual(
@@ -167,7 +167,9 @@ class TestAdditionalDataNSPL(TestCase):
 
                 additional_data = {}
                 nspl = NSPLSource()
-                nspl.update_additional_data(grant.data, additional_data)
+                nspl.update_additional_data(
+                    grant.data, grant.source_file.data, additional_data
+                )
 
                 self.assertIn("recipientOrganizationLocation", additional_data)
                 self.assertNotEqual(
@@ -191,7 +193,7 @@ class TestAdditionalDataNSPL(TestCase):
 
         additional_data = {}
         nspl = NSPLSource()
-        nspl.update_additional_data(grant.data, additional_data)
+        nspl.update_additional_data(grant.data, grant.source_file.data, additional_data)
 
         self.assertNotIn("recipientOrganizationLocation", additional_data)
         self.assertEqual(len(additional_data), 0)
@@ -205,7 +207,7 @@ class TestAdditionalDataNSPL(TestCase):
 
         additional_data = {}
         nspl = NSPLSource()
-        nspl.update_additional_data(grant.data, additional_data)
+        nspl.update_additional_data(grant.data, grant.source_file.data, additional_data)
 
         self.assertNotIn("recipientOrganizationLocation", additional_data)
         self.assertEqual(len(additional_data), 0)
@@ -220,7 +222,7 @@ class TestAdditionalDataNSPL(TestCase):
 
         additional_data = {"recipientOrgInfos": [{"postalCode": "EX364DE"}]}
         nspl = NSPLSource()
-        nspl.update_additional_data(grant.data, additional_data)
+        nspl.update_additional_data(grant.data, grant.source_file.data, additional_data)
 
         self.assertEqual(
             additional_data["recipientOrganizationLocation"],

--- a/datastore/tests/test_additional_data_tsgorgtype.py
+++ b/datastore/tests/test_additional_data_tsgorgtype.py
@@ -16,7 +16,9 @@ class TestTSGOrgTypeAdditionalData(TestCase):
 
         additional_data = {}
 
-        tsg_org_types.update_additional_data(grant.data, additional_data)
+        tsg_org_types.update_additional_data(
+            grant.data, grant.source_file.data, additional_data
+        )
 
         lowest_priority_org_type = (
             TSGOrgType.objects.order_by("priority").first().tsg_org_type
@@ -36,7 +38,9 @@ class TestTSGOrgTypeAdditionalData(TestCase):
         grant.data["fundingOrganization"][0]["id"] = "GB-GOR-PC390"
 
         additional_data = {}
-        tsg_org_types.update_additional_data(grant.data, additional_data)
+        tsg_org_types.update_additional_data(
+            grant.data, grant.source_file.data, additional_data
+        )
 
         self.assertTrue(
             "Lottery Distributor"

--- a/datastore/tests/test_additional_data_tsgrecipienttype.py
+++ b/datastore/tests/test_additional_data_tsgrecipienttype.py
@@ -13,11 +13,13 @@ class TestTSGRecipientTypes(TestCase):
             },
         }
 
+        source_file = {}
+
         additional_data_in = {}
 
         additional_data_out = {"TSGRecipientType": "Individual"}
 
-        source.update_additional_data(grant, additional_data_in)
+        source.update_additional_data(grant, source_file, additional_data_in)
 
         self.assertEqual(
             additional_data_in,
@@ -35,11 +37,13 @@ class TestTSGRecipientTypes(TestCase):
             ],
         }
 
+        source_file = {}
+
         additional_data_in = {}
 
         additional_data_out = {"TSGRecipientType": "Organisation"}
 
-        source.update_additional_data(grant, additional_data_in)
+        source.update_additional_data(grant, source_file, additional_data_in)
 
         self.assertEqual(
             additional_data_in,


### PR DESCRIPTION
A new additional data source `GrantMetadataSource` (name futureproofed for more metadata beyond just licenses): Adds `metadata/source_license` and `metadata/source_license_name` under `additional_data`.

Required changes to `update_additional_data` to pass the source file data through.

Towards #213 