### PR TITLE
monitoring: Track SourceFile access url + downtime

### DIFF
--- a/datastore/monitoring/metrics.py
+++ b/datastore/monitoring/metrics.py
@@ -206,6 +206,10 @@ def source_file_metrics(sourcefile: SourceFile) -> SourceFileMetrics:
         last_attempt_metadata["datetime_downloaded"]
     )
 
+    days_since_last_successful_download = (
+        last_attempt_downloaded_datetime - best_downloaded_datetime
+    ).days
+
     return SourceFileMetrics(
         last_successful_download_at=best_downloaded_datetime,
         last_download_attempt_at=last_attempt_downloaded_datetime,
@@ -215,9 +219,13 @@ def source_file_metrics(sourcefile: SourceFile) -> SourceFileMetrics:
         last_download_attempt_downloaded=last_attempt_metadata["downloads"],
         last_download_attempt_valid=last_attempt_metadata.get("valid"),
         last_download_attempt_error=last_attempt_metadata.get("error", ""),
-        days_since_last_successful_download=(
-            last_attempt_downloaded_datetime - best_downloaded_datetime
-        ).days,
+        days_since_last_successful_download=days_since_last_successful_download,
+        last_download_attempt_access_url=last_attempt.data["distribution"][0].get(
+            "accessURL"
+        ),
+        last_successful_download_was_at_least_7_days_ago=bool(
+            days_since_last_successful_download >= 7
+        ),
     )
 
 

--- a/datastore/monitoring/models.py
+++ b/datastore/monitoring/models.py
@@ -146,6 +146,9 @@ class SourceFileMetrics:
     last_download_attempt_valid: Optional[bool]
     last_download_attempt_error: str
     days_since_last_successful_download: int
+    # New metrics added later must be optional so that the serialiser can still work with older records
+    last_download_attempt_access_url: Optional[str]
+    last_successful_download_was_at_least_7_days_ago: Optional[bool]
 
 
 class SourceFileMetricsRecord(AbstractMetricsRecord):

--- a/datastore/tests/test_monitoring_metrics.py
+++ b/datastore/tests/test_monitoring_metrics.py
@@ -385,6 +385,9 @@ class TestMonitoringMetrics(TestCase):
         "last_download_attempt_valid",
         "last_download_attempt_error",
         "days_since_last_successful_download",
+        "last_download_attempt_download_url",
+        "last_download_attempt_access_url",
+        "last_successful_download_was_at_least_7_days_ago",
     ]
 
     def test_gather_metrics(self):


### PR DESCRIPTION
This commit adds two new metrics:
 * The SourceFile access url, to complement the already tracked download url
 * A simplified downtime metric of whether the SourceFile has been down for a week or more