### PR TITLE
monitoring: Add endpoint for per-publisher downtime alerts

### DIFF
--- a/datastore/api/monitoring/api.py
+++ b/datastore/api/monitoring/api.py
@@ -1,8 +1,10 @@
-from typing import Type
+import logging
+from typing import Type, cast
 from datetime import datetime, date
 
 from django.utils import timezone
 from rest_framework.generics import ListAPIView
+from rest_framework.request import Request
 from rest_framework.settings import api_settings
 from rest_framework_csv.renderers import CSVRenderer
 
@@ -18,7 +20,11 @@ from monitoring.serializers import (
     PublisherMetricsRecordSerializer,
     FunderMetricsRecordSerializer,
     SourceFileMetricsRecordSerializer,
+    PublisherMetricsRecordWithDownSourceFilesSerializer,
+    PublisherMetricsRecordWithDownSourceFilesSerializerCSV,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class SnapshotAPIView(ListAPIView):
@@ -60,6 +66,49 @@ class PublisherMetricsSnapshotAPIView(SnapshotAPIView):
     serializer_class = PublisherMetricsRecordSerializer
 
     metrics_record_model = PublisherMetricsRecord
+
+
+class PublisherSourceFileDownAPIView(SnapshotAPIView):
+    """
+    This view lists only Publishers that have an unavailable source file,
+    and info relevant to the down Source files.
+    """
+
+    renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (CSVRenderer,)
+
+    metrics_record_model = PublisherMetricsRecord
+
+    def get_serializer_class(self):
+        request: Request = cast(Request, self.request)
+        if request.accepted_renderer.format == "csv":
+            return PublisherMetricsRecordWithDownSourceFilesSerializerCSV
+        else:
+            return PublisherMetricsRecordWithDownSourceFilesSerializer
+
+    def get_queryset(self):
+        publisher_records = super().get_queryset()
+        down_publisher_prefixes = set()
+
+        # Theoretically this could be a single SQL query instead of a loop,
+        # but I couldn't get the obvious ways to work.
+        # This is NOT a performance critical area.
+        for pub in publisher_records.prefetch_related(
+            "snapshot__sourcefilemetricsrecord_set"
+        ):
+            if (
+                pub.snapshot.sourcefilemetricsrecord_set.filter(
+                    publisher_prefix=pub.publisher_prefix,
+                    metrics__last_successful_download_was_at_least_7_days_ago=True,
+                ).count()
+                > 0
+            ):
+                down_publisher_prefixes.add(pub.publisher_prefix)
+                logger.info(
+                    "Down publisher prefix: %s",
+                    pub.publisher_prefix,
+                )
+
+        return publisher_records.filter(publisher_prefix__in=down_publisher_prefixes)
 
 
 class FunderMetricsSnapshotAPIView(SnapshotAPIView):

--- a/datastore/api/monitoring/api.py
+++ b/datastore/api/monitoring/api.py
@@ -98,7 +98,7 @@ class PublisherSourceFileDownAPIView(SnapshotAPIView):
             if (
                 pub.snapshot.sourcefilemetricsrecord_set.filter(
                     publisher_prefix=pub.publisher_prefix,
-                    metrics__last_successful_download_was_at_least_7_days_ago=True,
+                    metrics__days_since_last_successful_download__gte=1,
                 ).count()
                 > 0
             ):

--- a/datastore/api/urls.py
+++ b/datastore/api/urls.py
@@ -97,6 +97,16 @@ urlpatterns = [
         name="publisher-metrics-snapshot",
     ),
     path(
+        "v1/monitoring/snapshot/publisher-down-sourcefiles/",
+        api.monitoring.api.PublisherSourceFileDownAPIView.as_view(),
+        name="publisher-down-sourcefiles",
+    ),
+    path(
+        "v1/monitoring/snapshot/publisher-down-sourcefiles/<str:snapshot_date>/",
+        api.monitoring.api.PublisherSourceFileDownAPIView.as_view(),
+        name="publisher-down-sourcefiles",
+    ),
+    path(
         "v1/monitoring/snapshot/funder/",
         api.monitoring.api.FunderMetricsSnapshotAPIView.as_view(),
         name="funder-metrics-snapshot",

--- a/datastore/monitoring/models.py
+++ b/datastore/monitoring/models.py
@@ -2,7 +2,7 @@ from typing import Optional, List
 from datetime import datetime, date
 from dataclasses import dataclass
 from django.db import models
-from django.db.models import OuterRef, Subquery, ForeignKey, DO_NOTHING
+from django.db.models import OuterRef, Subquery, ForeignKey, DO_NOTHING, SET_NULL
 from django.contrib.postgres.fields import ArrayField
 
 

--- a/datastore/monitoring/models.py
+++ b/datastore/monitoring/models.py
@@ -2,7 +2,7 @@ from typing import Optional, List
 from datetime import datetime, date
 from dataclasses import dataclass
 from django.db import models
-from django.db.models import OuterRef, Subquery, ForeignKey, DO_NOTHING, SET_NULL
+from django.db.models import OuterRef, Subquery, ForeignKey, DO_NOTHING
 from django.contrib.postgres.fields import ArrayField
 
 

--- a/datastore/monitoring/serializers.py
+++ b/datastore/monitoring/serializers.py
@@ -126,27 +126,28 @@ def list_to_csv(data: Iterable) -> str:
 class PublisherMetricsRecordWithDownSourceFilesSerializerCSV(
     PublisherMetricsRecordWithDownSourceFilesSerializer,
 ):
+    SOURCE_FILE_NESTED_CSV_FIELDS = [
+        "days_since_last_successful_download",
+        "last_download_attempt_download_url",
+        "last_download_attempt_access_url",
+    ]
+
     down_source_files = SerializerMethodField(method_name="get_down_source_files_csv")
 
-    @staticmethod
-    def get_down_source_files_csv(obj: PublisherMetricsRecord):
+    def get_down_source_files_csv(self, obj: PublisherMetricsRecord):
         down_source_files_records = obj.snapshot.sourcefilemetricsrecord_set.filter(
             publisher_prefix=obj.publisher_prefix,
-            metrics__last_successful_download_was_at_least_7_days_ago=True,
+            metrics__days_since_last_successful_download__gt=0,
         )
 
         # Nested CSV in a CSV field isn't very nice, but it works for the SalesForce integration
         data = {
-            "last_download_attempt_download_url": list_to_csv(
+            metric_name: list_to_csv(
                 down_source_files_records.values_list(
-                    "metrics__last_download_attempt_download_url", flat=True
+                    f"metrics__{metric_name}", flat=True
                 )
-            ),
-            "last_download_attempt_access_url": list_to_csv(
-                down_source_files_records.values_list(
-                    "metrics__last_download_attempt_access_url", flat=True
-                )
-            ),
+            )
+            for metric_name in self.SOURCE_FILE_NESTED_CSV_FIELDS
         }
 
         return data

--- a/datastore/monitoring/serializers.py
+++ b/datastore/monitoring/serializers.py
@@ -1,7 +1,11 @@
+import csv
+import io
+from typing import Iterable
 from datetime import datetime
 from typing import Dict, Any
 
 from rest_framework import serializers
+from rest_framework.fields import SerializerMethodField
 from rest_framework_dataclasses.serializers import DataclassSerializer
 
 from monitoring.models import (
@@ -46,38 +50,6 @@ class DatasetMetricsRecordSerializer(serializers.ModelSerializer):
     metrics = DatasetMetricsSerializer()
 
 
-# Publisher
-
-
-class PublisherMetricsSerializer(BaseMetricsSerializer):
-    class Meta:
-        dataclass = PublisherMetrics
-
-
-class PublisherMetricsRecordSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = PublisherMetricsRecord
-        fields = ["timestamp", "publisher_prefix", "metrics"]
-
-    metrics = PublisherMetricsSerializer()
-
-
-# Funder
-
-
-class FunderMetricsSerializer(BaseMetricsSerializer):
-    class Meta:
-        dataclass = FunderMetrics
-
-
-class FunderMetricsRecordSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = FunderMetricsRecord
-        fields = ["timestamp", "funder_org_id", "funder_non_primary_org_ids", "metrics"]
-
-    metrics = FunderMetricsSerializer()
-
-
 # SourceFile
 
 
@@ -102,3 +74,95 @@ class SourceFileMetricsRecordSerializer(serializers.ModelSerializer):
         ]
 
     metrics = SourceFileMetricsSerializer()
+
+
+# Publisher
+
+
+class PublisherMetricsSerializer(BaseMetricsSerializer):
+    class Meta:
+        dataclass = PublisherMetrics
+
+
+class PublisherMetricsRecordSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PublisherMetricsRecord
+        fields = ["timestamp", "publisher_prefix", "metrics"]
+
+    metrics = PublisherMetricsSerializer()
+
+
+class PublisherMetricsRecordWithDownSourceFilesSerializer(serializers.ModelSerializer):
+    """
+    Include info about down source files with each publisher.
+    """
+
+    class Meta:
+        model = PublisherMetricsRecord
+        fields = ["timestamp", "publisher_prefix", "metrics", "down_source_files"]
+
+    metrics = PublisherMetricsSerializer()
+    down_source_files = SerializerMethodField(method_name="get_down_source_files_json")
+
+    @staticmethod
+    def get_down_source_files_json(obj: PublisherMetricsRecord):
+        down_source_files_records = obj.snapshot.sourcefilemetricsrecord_set.filter(
+            publisher_prefix=obj.publisher_prefix,
+            metrics__last_successful_download_was_at_least_7_days_ago=True,
+        )
+        return SourceFileMetricsRecordSerializer(
+            down_source_files_records, many=True
+        ).data
+
+
+def list_to_csv(data: Iterable) -> str:
+    """Render a list as a single row of quoted CSV"""
+    f = io.StringIO()
+    writer = csv.writer(f, quoting=csv.QUOTE_ALL)
+    writer.writerow(data)
+    return f.getvalue()
+
+
+class PublisherMetricsRecordWithDownSourceFilesSerializerCSV(
+    PublisherMetricsRecordWithDownSourceFilesSerializer,
+):
+    down_source_files = SerializerMethodField(method_name="get_down_source_files_csv")
+
+    @staticmethod
+    def get_down_source_files_csv(obj: PublisherMetricsRecord):
+        down_source_files_records = obj.snapshot.sourcefilemetricsrecord_set.filter(
+            publisher_prefix=obj.publisher_prefix,
+            metrics__last_successful_download_was_at_least_7_days_ago=True,
+        )
+
+        # Nested CSV in a CSV field isn't very nice, but it works for the SalesForce integration
+        data = {
+            "last_download_attempt_download_url": list_to_csv(
+                down_source_files_records.values_list(
+                    "metrics__last_download_attempt_download_url", flat=True
+                )
+            ),
+            "last_download_attempt_access_url": list_to_csv(
+                down_source_files_records.values_list(
+                    "metrics__last_download_attempt_access_url", flat=True
+                )
+            ),
+        }
+
+        return data
+
+
+# Funder
+
+
+class FunderMetricsSerializer(BaseMetricsSerializer):
+    class Meta:
+        dataclass = FunderMetrics
+
+
+class FunderMetricsRecordSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FunderMetricsRecord
+        fields = ["timestamp", "funder_org_id", "funder_non_primary_org_ids", "metrics"]
+
+    metrics = FunderMetricsSerializer()

--- a/datastore/monitoring/serializers.py
+++ b/datastore/monitoring/serializers.py
@@ -4,6 +4,7 @@ from typing import Iterable
 from datetime import datetime
 from typing import Dict, Any
 
+from django.db.models import QuerySet
 from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
 from rest_framework_dataclasses.serializers import DataclassSerializer
@@ -99,20 +100,43 @@ class PublisherMetricsRecordWithDownSourceFilesSerializer(serializers.ModelSeria
 
     class Meta:
         model = PublisherMetricsRecord
-        fields = ["timestamp", "publisher_prefix", "metrics", "down_source_files"]
+        fields = [
+            "timestamp",
+            "publisher_prefix",
+            "metrics",
+            "down_source_files",
+            "has_sourcefile_where_last_successful_download_was_at_least_7_days_ago",
+        ]
 
     metrics = PublisherMetricsSerializer()
     down_source_files = SerializerMethodField(method_name="get_down_source_files_json")
+    has_sourcefile_where_last_successful_download_was_at_least_7_days_ago = (
+        SerializerMethodField()
+    )
 
-    @staticmethod
-    def get_down_source_files_json(obj: PublisherMetricsRecord):
-        down_source_files_records = obj.snapshot.sourcefilemetricsrecord_set.filter(
+    @classmethod
+    def _get_down_source_files(
+        self, obj: PublisherMetricsRecord
+    ) -> QuerySet[SourceFileMetricsRecord]:
+        return obj.snapshot.sourcefilemetricsrecord_set.filter(
             publisher_prefix=obj.publisher_prefix,
-            metrics__last_successful_download_was_at_least_7_days_ago=True,
+            metrics__days_since_last_successful_download__gt=0,
         )
+
+    @classmethod
+    def get_down_source_files_json(cls, obj: PublisherMetricsRecord):
         return SourceFileMetricsRecordSerializer(
-            down_source_files_records, many=True
+            cls._get_down_source_files(obj), many=True
         ).data
+
+    @classmethod
+    def get_has_sourcefile_where_last_successful_download_was_at_least_7_days_ago(
+        cls, obj: PublisherMetricsRecord
+    ) -> bool:
+        for sf in cls._get_down_source_files(obj):
+            if sf.metrics.get("days_since_last_successful_download", 0) >= 7:
+                return True
+        return False
 
 
 def list_to_csv(data: Iterable) -> str:
@@ -127,18 +151,22 @@ class PublisherMetricsRecordWithDownSourceFilesSerializerCSV(
     PublisherMetricsRecordWithDownSourceFilesSerializer,
 ):
     SOURCE_FILE_NESTED_CSV_FIELDS = [
-        "days_since_last_successful_download",
+        "last_successful_download_at",
+        "last_download_attempt_at",
         "last_download_attempt_download_url",
+        "last_download_attempt_downloaded",
+        "last_download_attempt_valid",
+        "last_download_attempt_error",
+        "days_since_last_successful_download",
         "last_download_attempt_access_url",
+        "last_successful_download_was_at_least_7_days_ago",
     ]
 
     down_source_files = SerializerMethodField(method_name="get_down_source_files_csv")
 
-    def get_down_source_files_csv(self, obj: PublisherMetricsRecord):
-        down_source_files_records = obj.snapshot.sourcefilemetricsrecord_set.filter(
-            publisher_prefix=obj.publisher_prefix,
-            metrics__days_since_last_successful_download__gt=0,
-        )
+    @classmethod
+    def get_down_source_files_csv(cls, obj: PublisherMetricsRecord):
+        down_source_files_records = cls._get_down_source_files(obj)
 
         # Nested CSV in a CSV field isn't very nice, but it works for the SalesForce integration
         data = {
@@ -147,7 +175,7 @@ class PublisherMetricsRecordWithDownSourceFilesSerializerCSV(
                     f"metrics__{metric_name}", flat=True
                 )
             )
-            for metric_name in self.SOURCE_FILE_NESTED_CSV_FIELDS
+            for metric_name in cls.SOURCE_FILE_NESTED_CSV_FIELDS
         }
 
         return data

--- a/datastore/tests/test_monitoring_metrics.py
+++ b/datastore/tests/test_monitoring_metrics.py
@@ -90,7 +90,7 @@ class TestMonitoringMetricsQueries(APITestCase):
 
     def get_down_publishers(self, snapshot_date: Optional[date] = None):
         query_kwargs = {}
-        if snapshot_date is not None:
+        if snapshot_date:
             query_kwargs = {"snapshot_date": snapshot_date.isoformat()}
 
         url = reverse("api:publisher-down-sourcefiles", kwargs=query_kwargs)

--- a/datastore/tests/test_monitoring_metrics.py
+++ b/datastore/tests/test_monitoring_metrics.py
@@ -1,3 +1,6 @@
+import csv
+import copy
+import io
 from datetime import timedelta, datetime, date
 import datetime as dt
 from typing import Dict, Any, List, Optional
@@ -26,6 +29,9 @@ from monitoring.models import (
     FunderMetricsRecord,
     SourceFileMetricsRecord,
     DatasetMetricsRecord,
+)
+from monitoring.serializers import (
+    PublisherMetricsRecordWithDownSourceFilesSerializerCSV,
 )
 
 from .fake_testdata import (
@@ -81,6 +87,38 @@ class TestMonitoringMetricsQueries(APITestCase):
 
     def get_funder_records(self, snapshot_date: Optional[date] = None):
         return self._get_records("funder", snapshot_date)
+
+    def get_down_publishers(self, snapshot_date: Optional[date] = None):
+        query_kwargs = {}
+        if snapshot_date is not None:
+            query_kwargs = {"snapshot_date": snapshot_date.isoformat()}
+
+        url = reverse(f"api:publisher-down-sourcefiles", kwargs=query_kwargs)
+        response = self.client.get(url, headers={"Accept": "text/csv"})
+        self.assertEqual(response.status_code, 200)
+        response_content = response.content.decode("utf-8")
+
+        def csv_row_to_list(csv_row: str) -> List[str]:
+            row_reader = csv.reader([csv_row])
+            return list(row_reader)[0]
+
+        down_publishers = {}
+        reader = csv.DictReader(io.StringIO(response_content))
+        for row in reader:
+            down_pub = copy.copy(row)
+            # Handle the nested CSV rows / list values
+            for (
+                metric_name
+            ) in (
+                PublisherMetricsRecordWithDownSourceFilesSerializerCSV.SOURCE_FILE_NESTED_CSV_FIELDS
+            ):
+                down_pub[f"down_source_files.{metric_name}"] = csv_row_to_list(
+                    down_pub[f"down_source_files.{metric_name}"]
+                )
+
+            down_publishers[down_pub["publisher_prefix"]] = down_pub
+
+        return down_publishers
 
     def test_new_publisher(self):
         # Check that:
@@ -180,6 +218,9 @@ class TestMonitoringMetricsQueries(APITestCase):
             0,
         )
 
+        # Check that the Publisher doesn't appear in Unavailable Publishers
+        self.assertNotIn(test_publisher.prefix, self.get_down_publishers().keys())
+
         # Fake two days of sourcefile downtime
         # Run two GetterRuns (as they tend to be about 24 hours apart, but can be slightly less,
         # so it can still be less than 1 full day difference after just one)
@@ -213,6 +254,17 @@ class TestMonitoringMetricsQueries(APITestCase):
                 "days_since_last_successful_download"
             ],
             1,
+        )
+
+        # Check that the Publisher does now appear in Unavailable Publishers
+        # along with the relevant SourceFile download URL
+        down_publishers = self.get_down_publishers()
+        self.assertIn(test_publisher.prefix, down_publishers.keys())
+        self.assertIn(
+            test_sourcefile.data["distribution"][0]["downloadURL"],
+            down_publishers[test_publisher.prefix][
+                "down_source_files.last_download_attempt_download_url"
+            ],
         )
 
         # Fake bringing the sourcefile back up

--- a/datastore/tests/test_monitoring_metrics.py
+++ b/datastore/tests/test_monitoring_metrics.py
@@ -93,7 +93,7 @@ class TestMonitoringMetricsQueries(APITestCase):
         if snapshot_date is not None:
             query_kwargs = {"snapshot_date": snapshot_date.isoformat()}
 
-        url = reverse(f"api:publisher-down-sourcefiles", kwargs=query_kwargs)
+        url = reverse("api:publisher-down-sourcefiles", kwargs=query_kwargs)
         response = self.client.get(url, headers={"Accept": "text/csv"})
         self.assertEqual(response.status_code, 200)
         response_content = response.content.decode("utf-8")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,4 @@
+version: "3.8"
 services:
   datastore-web:
     build: .


### PR DESCRIPTION
This commit implements a new monitoring API endpoint, which lists Publishers that have at least one currently unavailable Source File and associated infomation.