### PR TITLE
additional_data: geo_lookup: Use lsoa21 instead of lsoa11

### DIFF
--- a/datastore/additional_data/sources/geo_lookup.py
+++ b/datastore/additional_data/sources/geo_lookup.py
@@ -135,7 +135,8 @@ class GeoLookupSource(object):
                         area["sourceCode"] = location.get("geoCode")
                         additional_data["locationLookup"].append(area)
 
-        lsoa = additional_data.get("recipientOrganizationLocation", {}).get("lsoa11")
+        # recipientOrganizationLocation comes from nspl
+        lsoa = additional_data.get("recipientOrganizationLocation", {}).get("lsoa21")
         if lsoa:
             area = self.get_area_by_code(lsoa)
             if area:

--- a/datastore/tests/test_additional_data_geolookups.py
+++ b/datastore/tests/test_additional_data_geolookups.py
@@ -135,7 +135,7 @@ class TestAdditionalDataGeoLookup(TestCase):
             {"geoCode": self.EXISTING_AREA}
         ]
         additional_data = {
-            "recipientOrganizationLocation": {"lsoa11": self.EXISTING_AREA}
+            "recipientOrganizationLocation": {"lsoa21": self.EXISTING_AREA}
         }
 
         geo = GeoLookupSource()
@@ -177,7 +177,7 @@ class TestAdditionalDataGeoLookup(TestCase):
         del grant.data["beneficiaryLocation"]
 
         additional_data = {
-            "recipientOrganizationLocation": {"lsoa11": self.EXISTING_AREA}
+            "recipientOrganizationLocation": {"lsoa21": self.EXISTING_AREA}
         }
         geo = GeoLookupSource()
         geo.update_additional_data(grant.data, grant.source_file.data, additional_data)


### PR DESCRIPTION
The NSPL data that we're getting no longer contains lsoa11 which means poscode lookups from the grant data whilst return data that data doesn't contain any lsoa11 fields but does contain lsoa21 fields. To maintain our ability to geocode at higher levels such as region we need the fields that the lsoa data can provide.