### PR TITLE
load_datagetter_data: Clear our table of publisher entities before load

### DIFF
--- a/datastore/db/management/commands/load_datagetter_data.py
+++ b/datastore/db/management/commands/load_datagetter_data.py
@@ -142,7 +142,7 @@ class Command(BaseCommand):
 
         for ob in dataset:
             prefix = ob["publisher"]["prefix"]
-            publisher = db.Publisher.objects.create(
+            publisher, p_created = db.Publisher.objects.get_or_create(
                 getter_run=getter_run,
                 prefix=prefix,
                 data=ob["publisher"],

--- a/datastore/db/management/commands/load_datagetter_data.py
+++ b/datastore/db/management/commands/load_datagetter_data.py
@@ -137,9 +137,12 @@ class Command(BaseCommand):
 
         getter_run = db.GetterRun.objects.create()
 
+        # Clear out any previous datagetter run publishers
+        db.Publisher.objects.all().delete()
+
         for ob in dataset:
             prefix = ob["publisher"]["prefix"]
-            publisher, c = db.Publisher.objects.get_or_create(
+            publisher = db.Publisher.objects.create(
                 getter_run=getter_run,
                 prefix=prefix,
                 data=ob["publisher"],


### PR DESCRIPTION
This avoids any orphaned publishers being exported/kept in the database. We also have no other use for the publisher objects.