### PR TITLE
ui: status: Reduce the number of duplicate row counts

### DIFF
--- a/datastore/ui/templates/status.html
+++ b/datastore/ui/templates/status.html
@@ -43,12 +43,14 @@
         </thead>
         <tbody>
           <tr>
+            {% with latest_current.grant_set.all.count as latest_count %}
+            {% with latest_previous.grant_set.all.count as prev_count %}
             <td>Current Latest</td>
             <td>{{latest_current.updated|date:"r"}}</td>
-            <td>{{latest_current.grant_set.all.count|intcomma}}
-              {% if latest_current.grant_set.all.count > latest_previous.grant_set.all.count %}
+            <td>{{latest_count|intcomma}}
+              {% if latest_count > prev_count %}
               <span class="text-success">&#9650;</span>
-              {% elif latest_current.grant_set.all.count < latest_previous.grant_set.all.count %}
+              {% elif latest_count < prev_count %}
               <span class="text-danger">&#9660;</span>
               {% endif %}
             </td>
@@ -67,7 +69,7 @@
           <tr>
             <td>Previous Latest</td>
             <td>{{latest_previous.updated|date:"r"}}</td>
-            <td>{{latest_previous.grant_set.all.count|intcomma}}</td>
+            <td>{{prev_count|intcomma}}</td>
             <td>{{latest_previous.sourcefile_set.all.count|intcomma}}</td>
             <td>
               {% if not latest_previous %}
@@ -77,6 +79,9 @@
               {% endif %}
             </td>
           </tr>
+
+          {% endwith %}
+          {% endwith %}
 
           <tr>
             <td>Datagetter</td>


### PR DESCRIPTION
The number of grants in different datasets is unnecessarily evaluated multiple times. Store the value in a template variable instead.