### PR TITLE
Monitoring non-GBP currencies

### DIFF
--- a/datastore/data_quality/management/commands/rewrite_quality_data.py
+++ b/datastore/data_quality/management/commands/rewrite_quality_data.py
@@ -107,30 +107,32 @@ def rewrite_quality_data(
                 }
             )
 
-        if not threads:
-            for sf in process_sf_list:
-                process_source_file(sf)
-        else:
-            with Pool(threads) as process_pool:
-                try:
+        try:
+            if not threads:
+                source_file_results = [
+                    process_source_file(sf) for sf in process_sf_list
+                ]
+
+            else:
+                with Pool(threads) as process_pool:
                     source_file_results = process_pool.map(
                         process_source_file, process_sf_list
                     )
-                except Exception as e:
-                    print(f"Error generating quality data {e}")
 
-        for source_file_result in source_file_results:
-            if source_file_result is None:
-                continue
+            for source_file_result in source_file_results:
+                if source_file_result is None:
+                    continue
 
-            sf = db.SourceFile.objects.get(pk=source_file_result["pk"])
-            sf.quality = source_file_result["quality"]
-            sf.aggregate = source_file_result["aggregate"]
-            sourcefile_objs_for_update.append(sf)
+                sf = db.SourceFile.objects.get(pk=source_file_result["pk"])
+                sf.quality = source_file_result["quality"]
+                sf.aggregate = source_file_result["aggregate"]
+                sourcefile_objs_for_update.append(sf)
 
-        db.SourceFile.objects.bulk_update(
-            sourcefile_objs_for_update, ["quality", "aggregate"], batch_size=10000
-        )
+            db.SourceFile.objects.bulk_update(
+                sourcefile_objs_for_update, ["quality", "aggregate"], batch_size=10000
+            )
+        except Exception as e:
+            print(f"Error generating quality data {e}")
 
     def process_publishers(source_file_: db.SourceFile):
         """Updates the publisher data with aggregates and quality data relating to their source files"""

--- a/datastore/data_quality/quality_data.py
+++ b/datastore/data_quality/quality_data.py
@@ -232,20 +232,27 @@ class SourceFilesStats(object):
         ).aggregate(Sum("total"))["total__sum"]
 
     def get_total_gbp(self):
+        return self.get_total_currency("GBP")
+
+    def get_total_currency(self, currency):
+        """Returns the sum of the amounts of the publisher's grants in the given currency."""
         try:
-            total_gbp = float(
+            total = float(
                 self.source_file_set.annotate(
                     total=RawSQL(
-                        "((aggregate->'currencies'->'GBP'->>%s)::float)",
-                        ("total_amount",),
+                        "((aggregate->'currencies'->%s->>%s)::float)",
+                        (
+                            currency,
+                            "total_amount",
+                        ),
                     )
                 ).aggregate(Sum("total"))["total__sum"]
             )
         except TypeError:
-            # Happens if the source file has no GBP
-            total_gbp = 0
+            # Happens if the source file has no grants of the currency
+            total = 0
 
-        return total_gbp
+        return total
 
     def get_total_publishers(self):
         return self.source_file_set.distinct("data__publisher__prefix").count()
@@ -573,6 +580,8 @@ def generate_stats(mode, source_file_set):
             "total": {
                 "grants": source_files_stats.get_total_grants(),
                 "GBP": source_files_stats.get_total_gbp(),
+                "EUR": source_files_stats.get_total_currency("EUR"),
+                "USD": source_files_stats.get_total_currency("USD"),
                 "publishers": source_files_stats.get_total_publishers(),
                 "recipientOrganisations": source_files_stats.get_total_recipient_organisations(),
                 "recipientIndividuals": source_files_stats.get_total_recipient_individuals(),

--- a/datastore/monitoring/metrics.py
+++ b/datastore/monitoring/metrics.py
@@ -73,6 +73,8 @@ def dataset_metrics(latest: Latest) -> DatasetMetrics:
         # In postgresql JSONB values must be cast before aggregate functions
         total_grants=Sum(Cast("aggregate__count", BigIntegerField())),
         total_gbp=Sum(Cast("aggregate__currencies__GBP__total_amount", FloatField())),
+        total_eur=Sum(Cast("aggregate__currencies__EUR__total_amount", FloatField())),
+        total_usd=Sum(Cast("aggregate__currencies__USD__total_amount", FloatField())),
     )
 
     gr_agg = grants.aggregate(
@@ -88,6 +90,8 @@ def dataset_metrics(latest: Latest) -> DatasetMetrics:
         total_grants=sf_agg["total_grants"],
         total_grants_to_individuals=gr_agg["total_grants_to_individuals"],
         total_amount_awarded_gbp=sf_agg["total_gbp"],
+        total_amount_awarded_eur=sf_agg["total_eur"],
+        total_amount_awarded_usd=sf_agg["total_usd"],
         total_publishers=Publisher.objects.all().count(),
         total_funders=Funder.objects.count(),
         total_recipient_organisations=Recipient.objects.count(),
@@ -118,6 +122,8 @@ def publisher_metrics(publisher: Publisher) -> PublisherMetrics:
     return PublisherMetrics(
         total_grants=publisher.aggregate["total"].get("grants", None),
         total_gbp=publisher.aggregate["total"].get("GBP", None),
+        total_eur=publisher.aggregate["total"].get("EUR", None),
+        total_usd=publisher.aggregate["total"].get("USD", None),
         total_funders=publisher.aggregate["total"].get("funders", None),
         total_recipient_individuals=publisher.aggregate["total"].get(
             "recipientIndividuals", None
@@ -158,20 +164,34 @@ def gather_publisher_metrics(
 
 def funder_metrics(funder: Funder) -> FunderMetrics:
 
-    total_gbp = 0
-    try:
-        total_gbp += funder.aggregate["currencies"]["GBP"]["recipient_org"]["total"]
-    except KeyError:
-        pass
+    totals = {
+        "GBP": 0,
+        "EUR": 0,
+        "USD": 0,
+    }
 
-    try:
-        total_gbp += funder.aggregate["currencies"]["GBP"]["recipient_ind"]["total"]
-    except KeyError:
-        pass
+    for currency in totals.keys():
+        try:
+            # Handle Grants to Organisations
+            totals[currency] += funder.aggregate["currencies"][currency][
+                "recipient_org"
+            ]["total"]
+        except KeyError:
+            pass
+
+        try:
+            # Handle Grants to Individuals
+            totals[currency] += funder.aggregate["currencies"][currency][
+                "recipient_ind"
+            ]["total"]
+        except KeyError:
+            pass
 
     return FunderMetrics(
         total_grants=funder.aggregate.get("grants"),
-        total_gbp=total_gbp,
+        total_gbp=totals["GBP"],
+        total_eur=totals["EUR"],
+        total_usd=totals["USD"],
         latest_award_date=funder.aggregate.get("maxAwardDate"),
         earliest_award_date=funder.aggregate.get("minAwardDate"),
     )

--- a/datastore/monitoring/models.py
+++ b/datastore/monitoring/models.py
@@ -237,7 +237,10 @@ class DatasetMetrics:
 
     total_grants: int
     total_grants_to_individuals: int
+    # FIXME: Currency amounts should be floats
     total_amount_awarded_gbp: int
+    total_amount_awarded_eur: Optional[float]
+    total_amount_awarded_usd: Optional[float]
     total_publishers: int
     total_funders: int
     total_recipient_individuals: int
@@ -253,7 +256,9 @@ class DatasetMetricsRecord(AbstractMetricsRecord):
 @dataclass
 class PublisherMetrics:
     total_grants: int
-    total_gbp: float
+    total_gbp: Optional[float]  # May be None for non-UK funders with no GBP grants
+    total_eur: Optional[float]
+    total_usd: Optional[float]
     total_funders: int
     total_recipient_individuals: int
     total_recipient_organisations: int
@@ -279,6 +284,8 @@ class PublisherMetricsRecord(AbstractMetricsRecord):
 class FunderMetrics:
     total_grants: int
     total_gbp: Optional[float]  # May be None for non-UK funders with no GBP grants
+    total_eur: Optional[float]
+    total_usd: Optional[float]
     latest_award_date: date
     earliest_award_date: date
 
@@ -288,6 +295,8 @@ class FunderMetricsRecord(AbstractMetricsRecord):
     TRACKED_METRICS = [
         "total_grants",
         "total_gbp",
+        "total_eur",
+        "total_usd",
         "latest_award_date",
         "earliest_award_date",
     ]

--- a/datastore/tests/fake_testdata.py
+++ b/datastore/tests/fake_testdata.py
@@ -25,8 +25,8 @@ from monitoring.metrics import (
 logger = logging.getLogger(__name__)
 
 
-@transaction.atomic
 @contextmanager
+@transaction.atomic
 def fake_getter_run(
     fake: faker.Faker,
     timestamp: Optional[datetime] = None,
@@ -75,7 +75,7 @@ def fake_getter_run(
     Latest.update()
     update_entities()
     # Race conditions seem to happen when running tests if threads are enabled
-    rewrite_quality_data("latest", publisher_only=True, threads=0)
+    rewrite_quality_data("latest", threads=0)
     gather_metrics()
 
 
@@ -143,145 +143,11 @@ def fake_sourcefile(
         },
     }
 
-    sf_quality = {
-        "TitleLength": {"fail": False, "count": 0},
-        "NoDataSource": {
-            "fail": True,
-            "count": 39,
-            "heading": '100% of grants do not have <span class="highlight-background-text">Data Source</span> information',
-            "percentage": 1.0,
-        },
-        "NoLastModified": {
-            "fail": True,
-            "count": 39,
-            "heading": '100% of grants do not have <span class="highlight-background-text">Last Modified</span> information',
-            "percentage": 1.0,
-        },
-        "NoGrantProgramme": {
-            "fail": True,
-            "count": 39,
-            "heading": '100% of grants do not contain any <span class="highlight-background-text">Grant Programme</span> fields',
-            "percentage": 1.0,
-        },
-        "FundingOrg360GPrefix": {"fail": False, "count": 0},
-        "TitleDescriptionSame": {"fail": False, "count": 0},
-        "NoBeneficiaryLocation": {"fail": False, "count": 0},
-        "IncompleteRecipientOrg": {
-            "fail": True,
-            "count": 39,
-            "heading": "100% of recipient organisation grants do not have recipient organisation location information",
-            "percentage": 1.0,
-        },
-        "RecipientOrg360GPrefix": {
-            "fail": False,
-            "count": 22,
-            "heading": "56% of recipient organisation grants have a <span class=\"highlight-background-text\">Recipient Org:Identifier</span> that starts '360G-'",
-            "percentage": 0.5641025641025641,
-        },
-        "ClassificationNotPresent": {
-            "fail": True,
-            "count": 39,
-            "heading": "100% of grants do not contain classifications/0/title field",
-            "percentage": 1.0,
-        },
-        "PlannedDurationNotPresent": {
-            "fail": True,
-            "count": 39,
-            "heading": "100% of grants do not contain plannedDates/0/duration or (plannedDates/startDate and plannedDates/endDate) field",
-            "percentage": 1.0,
-        },
-        "RecipientOrgPrefixExternal": {
-            "fail": False,
-            "count": 17,
-            "heading": "Recipient Orgs with external org identifier",
-            "percentage": 0.4358974358974359,
-        },
-        "GrantProgrammeTitleNotPresent": {
-            "fail": True,
-            "count": 39,
-            "heading": "100% of grants do not contain grantProgramme/0/title field",
-            "percentage": 1.0,
-        },
-        "IndividualsCodeListsNotPresent": {"fail": False, "count": 0},
-        "RecipientOrgPrefix50pcExternal": {
-            "fail": True,
-            "count": 8.5,
-            "percentage": 0.4358974358974359,
-        },
-        "BeneficiaryLocationNameNotPresent": {"fail": False, "count": 0},
-        "NoRecipientOrgCompanyCharityNumber": {"fail": False, "count": 0},
-        "BeneficiaryLocationGeoCodeNotPresent": {"fail": False, "count": 0},
-        "BeneficiaryLocationCountryCodeNotPresent": {
-            "fail": True,
-            "count": 39,
-            "heading": "100% of grants do not contain beneficiaryLocation/0/countryCode field",
-            "percentage": 1.0,
-        },
-    }
-
-    sf_aggregate = {
-        "count": 39,
-        "funders": ["GB-LAE-OXO"],
-        "currencies": {
-            "GBP": {
-                "count": 39,
-                "max_amount": 190000,
-                "min_amount": 1000,
-                "total_amount": 782531,
-                "currency_symbol": "&pound;",
-            }
-        },
-        "award_years": {"2018": 39},
-        "max_award_date": "2018-04-19",
-        "min_award_date": "2018-02-13",
-        "recipient_org_types": {"CHC": 15, "COH": 2},
-        "recipient_individuals": 0,
-        "recipient_organisations": [
-            "360G-CHC-1032845",
-            "360G-CHC-1049343",
-            "360G-CHC-1055305",
-            "360G-CHC-1055914",
-            "360G-CHC-1063068",
-            "360G-CHC-1084256",
-            "360G-CHC-1123488",
-            "360G-CHC-1140556",
-            "360G-CHC-1150626",
-            "360G-CHC-1160320",
-            "360G-CHC-1161597",
-            "360G-CHC-1173191",
-            "360G-CHC-270852",
-            "360G-CHC-274222",
-            "360G-CHC-299903",
-            "360G-CHC-313035",
-            "360G-CHC-5138370",
-            "360G-CHC-6835605",
-            "360G-CHC-900039",
-            "360G-OxfordCC-Cutteslowe-Seniors",
-            "360G-OxfordCC-Oxford-International-Links",
-            "360G-OxfordCC-Wood-Farm-Youth-Centre",
-            "GB-CHC-1041014",
-            "GB-CHC-1070805",
-            "GB-CHC-1079495",
-            "GB-CHC-1092265",
-            "GB-CHC-1107094",
-            "GB-CHC-1108612",
-            "GB-CHC-1108679",
-            "GB-CHC-1137129",
-            "GB-CHC-1144821",
-            "GB-CHC-1154860",
-            "GB-CHC-1172048",
-            "GB-CHC-273172",
-            "GB-CHC-299533",
-            "GB-COH-03591512",
-            "GB-COH-09605591",
-        ],
-    }
-
     sourcefile = SourceFile.objects.create(
         data=sf_data,
         getter_run=getter_run,
-        quality=sf_quality,
-        aggregate=sf_aggregate,
+        quality={},
+        aggregate={},
     )
     return sourcefile
 
@@ -342,6 +208,7 @@ def fake_grant(
     funder: GrantOrganisation,
     recipient: GrantOrganisation,
     amount_awarded: Optional[int] = None,
+    currency: str = "GBP",
 ) -> Grant:
     grant_id = f"{sourcefile.data['publisher']['prefix']}-{fake.uuid4()}"
     grant_award_date = fake.past_date(tzinfo=timezone.utc).isoformat()
@@ -353,7 +220,7 @@ def fake_grant(
             "Decision Notes": fake.sentence(),
             "Project Detail": fake.paragraph(),
         },
-        "currency": "GBP",
+        "currency": currency,
         "awardDate": grant_award_date,
         "dataSource": fake.url(),
         "description": fake.paragraph(),

--- a/datastore/tests/test_api.py
+++ b/datastore/tests/test_api.py
@@ -16,6 +16,8 @@ class DashBoardAPITests(TestCase):
                 "total": {
                     "grants": 50,
                     "GBP": 25047.0,
+                    "EUR": 0,
+                    "USD": 0,
                     "publishers": 10,
                     "recipientOrganisations": 2,
                     "recipientIndividuals": 0,
@@ -56,6 +58,8 @@ class DashBoardAPITests(TestCase):
                 "total": {
                     "grants": 50,
                     "GBP": 25047.0,
+                    "EUR": 0,
+                    "USD": 0,
                     "publishers": 10,
                     "recipientOrganisations": 2,
                     "recipientIndividuals": 0,

--- a/datastore/tests/test_monitoring_metrics.py
+++ b/datastore/tests/test_monitoring_metrics.py
@@ -29,7 +29,6 @@ from monitoring.models import (
     FunderMetricsRecord,
     SourceFileMetricsRecord,
     DatasetMetricsRecord,
-    MonitoringSnapshot,
 )
 from monitoring.serializers import (
     PublisherMetricsRecordWithDownSourceFilesSerializerCSV,

--- a/datastore/tests/test_monitoring_metrics.py
+++ b/datastore/tests/test_monitoring_metrics.py
@@ -29,6 +29,7 @@ from monitoring.models import (
     FunderMetricsRecord,
     SourceFileMetricsRecord,
     DatasetMetricsRecord,
+    MonitoringSnapshot,
 )
 from monitoring.serializers import (
     PublisherMetricsRecordWithDownSourceFilesSerializerCSV,
@@ -608,6 +609,36 @@ class TestMonitoringMetricsQueries(APITestCase):
         )
         self.assertEqual(len(funder_records), 1)
         self.assertEqual(funder_records[0]["metrics"]["total_gbp"], 200)
+
+    def test_non_gbp_currencies(self):
+        fake = faker.Faker()
+
+        funder = fake_grant_org(fake)
+        recipient = fake_grant_org(fake)
+        test_publisher = fake_publisher_info(fake)
+
+        # Create a publisher with a couple of non-GBP grants
+        with fake_getter_run(fake) as getter_run_1:
+            sourcefile = fake_sourcefile(fake, getter_run_1, test_publisher)
+            fake_grant(fake, sourcefile, funder, recipient, currency="EUR")
+            fake_grant(fake, sourcefile, funder, recipient, currency="USD")
+
+        # Check that non-GBP amounts are reflected in monitoring metrics
+        # and that GBP totals should be zero given there are no GBP grants
+        dataset_metrics = DatasetMetricsRecord.objects.all()[0]
+        self.assertFalse(dataset_metrics.metrics.get("total_amount_awarded_gbp"))
+        self.assertGreater(dataset_metrics.metrics["total_amount_awarded_eur"], 0)
+        self.assertGreater(dataset_metrics.metrics["total_amount_awarded_usd"], 0)
+
+        publisher_metrics = PublisherMetricsRecord.objects.all()[0]
+        self.assertFalse(publisher_metrics.metrics.get("total_gbp"))
+        self.assertGreater(publisher_metrics.metrics["total_eur"], 0)
+        self.assertGreater(publisher_metrics.metrics["total_usd"], 0)
+
+        funder_metrics = FunderMetricsRecord.objects.all()[0]
+        self.assertFalse(funder_metrics.metrics.get("total_gbp"))
+        self.assertGreater(funder_metrics.metrics["total_eur"], 0)
+        self.assertGreater(funder_metrics.metrics["total_usd"], 0)
 
 
 class TestMonitoringMetrics(TestCase):

--- a/datastore/tests/test_quality_data.py
+++ b/datastore/tests/test_quality_data.py
@@ -140,6 +140,8 @@ class TestDataQualityData(TestCase):
             "total": {
                 "grants": 5,
                 "GBP": 3041.0,
+                "EUR": 0,
+                "USD": 0,
                 "publishers": 1,
                 "recipientOrganisations": 1,
                 "recipientIndividuals": 0,


### PR DESCRIPTION
This PR:
* Enables tracking select non-GBP currencies in the monitoring metrics (only EUR and USD for now).
* Fixes a bug in rewrite_quality_data where SourceFile aggregate data would fail to be calculated when threading was disabled.
* Enables creating fake grants in the test framework that have currencies other than GBP, and SourceFile aggregate data is now calculated properly from fake grants, rather than being directly mocked with static data.