### PR TITLE
quality_data: Reduce default thread count

### DIFF
--- a/datastore/data_quality/management/commands/rewrite_quality_data.py
+++ b/datastore/data_quality/management/commands/rewrite_quality_data.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--threads",
             type=int,
-            default=8,
+            default=3,
             help="Number of threads to use for processing quality data. Set to 0 to disable threading.",
         )
 


### PR DESCRIPTION
Reduce memory usage by reducing the default number of quality processing threads from 8 to 3