### PR TITLE
monitoring: Show only the latest dataset in snapshot API endpoint

### DIFF
--- a/datastore/api/monitoring/api.py
+++ b/datastore/api/monitoring/api.py
@@ -60,6 +60,10 @@ class DatasetMetricsSnapshotAPIView(SnapshotAPIView):
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (CSVRenderer,)
     serializer_class = DatasetMetricsRecordSerializer
 
+    def get_queryset(self):
+        # Show headline stats for the most recent dataset
+        return super().get_queryset().order_by("-timestamp")[0:1]
+
     metrics_record_model = DatasetMetricsRecord
 
 


### PR DESCRIPTION
The dataset snapshot API currently lists *all* datasets ever recorded, but given a new dataset is create every day, the output of this endpoint will grow forever.

This endpoint is currently only used by the Monitoring sheet to determine if it needs to update itsself, so it's important to keep the size of the output small.

This does not affect the contents of db_dataset, so 360 internal reporting will still have access to all historical data.

This endpoint can still show past dates' headline stats by passing the data parameter to the endpoint.