### PR TITLE
Add additional_data metadata to Grant API

### DIFF
--- a/datastore/api/org/serializers.py
+++ b/datastore/api/org/serializers.py
@@ -7,8 +7,11 @@ from drf_spectacular.types import OpenApiTypes
 from rest_framework_dataclasses.serializers import DataclassSerializer
 from typing import Optional
 
+import logging
 import db.models as db
 from api.org import models
+
+logger = logging.getLogger(__name__)
 
 
 class OrganisationRefSerializer(DataclassSerializer):
@@ -261,11 +264,13 @@ class GrantSerializer(serializers.ModelSerializer):
             "publisher",
             "recipients",
             "funders",
+            "additional_data_metadata",
         ]
 
     data = GrantDataField()
 
     data_license = serializers.SerializerMethodField()
+    additional_data_metadata = serializers.SerializerMethodField()
 
     publisher = serializers.SerializerMethodField()
     recipients = serializers.SerializerMethodField()
@@ -279,6 +284,37 @@ class GrantSerializer(serializers.ModelSerializer):
                 name=grant.source_file.data.get("license_name"),
             )
         ).data
+
+    @extend_schema_field(OpenApiTypes.OBJECT)
+    def get_additional_data_metadata(self, grant):
+        """
+        Return the aggregated metadata object added to grant.additional_data by
+        GrantMetadataSource (if present). Returns None when not present.
+        """
+        try:
+            if not grant.additional_data:
+                return None
+            return grant.additional_data.get("metadata")
+        except Exception as e:
+            logger.exception(
+                "Failed to retrieve additional_data_metadata for grant %s: %s",
+                getattr(grant, "grant_id", None),
+                e,
+            )
+            # Return None to avoid breaking serialization; field will be removed by to_representation.
+            return None
+
+    def to_representation(self, instance):
+        """
+        Ensure not to add `additional_data_metadata` key for grants which have no metadata.
+        Returning None from get_additional_data_metadata would otherwise cause the field to appear
+        with a null value; remove it to preserve the previous API shape.
+        """
+        ret = super().to_representation(instance)
+        # Remove field when metadata is not present to avoid changing response shape
+        if ret.get("additional_data_metadata", None) is None:
+            ret.pop("additional_data_metadata", None)
+        return ret
 
     @extend_schema_field(OrganisationRefSerializer)
     def get_publisher(self, grant):

--- a/datastore/tests/test_additional_data_license.py
+++ b/datastore/tests/test_additional_data_license.py
@@ -6,6 +6,7 @@ from additional_data.sources.geo_lookup import GeoLookupSource
 from additional_data.sources.nspl import NSPLSource
 from additional_data.sources.codelist_code import CodeListSource
 from db.models import Grant
+from api.org.serializers import GrantSerializer
 
 OGL_V3 = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 CC_BY_4 = "https://creativecommons.org/licenses/by/4.0/"
@@ -126,3 +127,34 @@ class TestAdditionalDataSourceLicences(TestCase):
             CC_BY_4,
             "CodeListSource has wrong license.",
         )
+
+
+class TestGrantSerializerAdditionalData(TestCase):
+    fixtures = ["test_data.json"]
+
+    def test_additional_data_metadata_exposed(self):
+        """
+        Ensure GrantSerializer exposes additional_data['metadata'] via
+        the additional_data_metadata field when present.
+        """
+        grant = Grant.objects.first()
+
+        # Populate additional_data metadata for the grant (simulate rewrite_additional_data run)
+        sample_metadata = {
+            "source_license_name": "Example License Name",
+            "source_license": "https://example.org/licenses/ex-license",
+            "sources_metadata": {
+                "codeListLookup": {
+                    "license": "https://creativecommons.org/licenses/by/4.0/"
+                }
+            },
+        }
+
+        grant.additional_data = {"metadata": sample_metadata}
+        grant.save()
+
+        serialized = GrantSerializer(grant).data
+
+        # Verify field presence and content
+        self.assertIn("additional_data_metadata", serialized)
+        self.assertEqual(serialized["additional_data_metadata"], sample_metadata)


### PR DESCRIPTION
Relates to https://github.com/ThreeSixtyGiving/datastore/issues/214

- Exposes additional_data metadata (publisher source license and aggregated additional_data source licences) on the Grant API response.
- Adds serializer field additional_data_metadata to GrantSerializer and a test verifying the field is present and returns the expected metadata.

Previous PR
- https://github.com/ThreeSixtyGiving/datastore/pull/258
- https://github.com/ThreeSixtyGiving/datastore/pull/335